### PR TITLE
ci(release): use installation access token to checkout and push back changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,18 +14,14 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          cache: npm
-          node-version: lts/*
-      - run: npm ci
-      - run: npm run build
-      - uses: ./ # Uses the action in the root directory
+      - uses: actions/create-github-app-token@v1
         id: app-token
         with:
           app_id: ${{ vars.RELEASER_APP_ID }}
           private_key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - run: npm install --no-save @semantic-release/git semantic-release-plugin-github-breaking-version-tag
       - run: npx semantic-release
         env:


### PR DESCRIPTION
this should resolve the failing release workflow, it tries to push back with GITHUB_TOKEN and that one cannot bypass our branch protection rule

closes #25 