### PR TITLE
build(dependabot): Group dependency updates by type and configure commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
         dependency-type: "production"
       development-dependencies:
         dependency-type: "development"
+    commit-message:
+      prefix: "fix"
+      prefix-development: "build"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,18 @@
       "main"
     ],
     "plugins": [
-      "@semantic-release/commit-analyzer",
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "releaseRules": [
+            {
+              "type": "build",
+              "scope": "deps",
+              "release": "patch"
+            }
+          ]
+        }
+      ],
       "@semantic-release/release-notes-generator",
       "@semantic-release/github",
       "semantic-release-plugin-github-breaking-version-tag",

--- a/package.json
+++ b/package.json
@@ -24,18 +24,7 @@
       "main"
     ],
     "plugins": [
-      [
-        "@semantic-release/commit-analyzer",
-        {
-          "releaseRules": [
-            {
-              "type": "build",
-              "scope": "deps",
-              "release": "patch"
-            }
-          ]
-        }
-      ],
+      "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
       "@semantic-release/github",
       "semantic-release-plugin-github-breaking-version-tag",


### PR DESCRIPTION
- Group production and development dependency updates
- Configure dependency update commit prefixes to release on production dependency updates

  Dependabot commit messages before:

  - `build(deps): bump semver from 7.5.1 to 7.5.4`
  - `build(deps-dev): bump dotenv from 16.0.3 to 16.3.1`

  Dependabot commit messages after:

  - `fix(deps): bump semver from 7.5.1 to 7.5.4`
  - `build(deps-dev): bump dotenv from 16.0.3 to 16.3.1` (no change to dev dependencies)