### PR TITLE
fix: mask the installation token in logs

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -52,6 +52,9 @@ export async function main(
     repositoryNames: [repo],
   });
 
+  // Register the secret with the runner to ensure it is masked in logs
+  core.setSecret(authentication.token);
+
   core.setOutput("token", authentication.token);
 
   // Make token accessible to post function (so we can invalidate it)

--- a/lib/main.js
+++ b/lib/main.js
@@ -52,7 +52,7 @@ export async function main(
     repositoryNames: [repo],
   });
 
-  // Register the secret with the runner to ensure it is masked in logs
+  // Register the token with the runner as a secret to ensure it is masked in logs
   core.setSecret(authentication.token);
 
   core.setOutput("token", authentication.token);


### PR DESCRIPTION
The runner will automatically mask GitHub token formats it recognizes, but sometimes a new pattern rolls out before the runner is updated to recognize it.

closes #13