### PR TITLE
fix: check for token before revoking

### DIFF
--- a/lib/post.js
+++ b/lib/post.js
@@ -10,13 +10,13 @@ import { request } from "@octokit/request";
 export async function post(core, request) {
   const token = core.getState("token");
 
-  if (token) {
-    await request("DELETE /installation/token", {
-      headers: {
-        authorization: `token ${token}`,
-      },
-    });
+  if (!token) return;
   
-    core.info("Token revoked");
-  }
+  await request("DELETE /installation/token", {
+    headers: {
+      authorization: `token ${token}`,
+    },
+  });
+
+  core.info("Token revoked");
 }

--- a/lib/post.js
+++ b/lib/post.js
@@ -10,11 +10,13 @@ import { request } from "@octokit/request";
 export async function post(core, request) {
   const token = core.getState("token");
 
-  await request("DELETE /installation/token", {
-    headers: {
-      authorization: `token ${token}`,
-    },
-  });
-
-  core.info("Token revoked");
+  if (token) {
+    await request("DELETE /installation/token", {
+      headers: {
+        authorization: `token ${token}`,
+      },
+    });
+  
+    core.info("Token revoked");
+  }
 }


### PR DESCRIPTION
Check before trying to revoke the token, in case the token generation failed. Otherwise the post step will throw an error.