### PR TITLE
feat: add GitHub Enterprise Server (GHES) support

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -4,6 +4,10 @@ import core from "@actions/core";
 import { createAppAuth } from "@octokit/auth-app";
 import { request } from "@octokit/request";
 
+request.defaults({
+  baseUrl: process.env["GITHUB_API_URL"],
+});
+
 /**
  * @param {string} appId
  * @param {string} privateKey

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,10 +4,6 @@ import core from "@actions/core";
 import { createAppAuth } from "@octokit/auth-app";
 import { request } from "@octokit/request";
 
-request.defaults({
-  baseUrl: process.env["GITHUB_API_URL"],
-});
-
 /**
  * @param {string} appId
  * @param {string} privateKey

--- a/lib/post.js
+++ b/lib/post.js
@@ -3,10 +3,6 @@
 import core from "@actions/core";
 import { request } from "@octokit/request";
 
-request.defaults({
-  baseUrl: process.env["GITHUB_API_URL"],
-});
-
 /**
  * @param {core} core
  * @param {request} request

--- a/lib/post.js
+++ b/lib/post.js
@@ -3,6 +3,10 @@
 import core from "@actions/core";
 import { request } from "@octokit/request";
 
+request.defaults({
+  baseUrl: process.env["GITHUB_API_URL"],
+});
+
 /**
  * @param {core} core
  * @param {request} request
@@ -11,7 +15,7 @@ export async function post(core, request) {
   const token = core.getState("token");
 
   if (!token) return;
-  
+
   await request("DELETE /installation/token", {
     headers: {
       authorization: `token ${token}`,

--- a/main.js
+++ b/main.js
@@ -15,9 +15,16 @@ const privateKey = core.getInput("private_key");
 
 const repository = process.env.GITHUB_REPOSITORY;
 
-main(appId, privateKey, repository, core, createAppAuth, request).catch(
-  (error) => {
-    console.error(error);
-    core.setFailed(error.message);
-  }
-);
+main(
+  appId,
+  privateKey,
+  repository,
+  core,
+  createAppAuth,
+  request.defaults({
+    baseUrl: process.env["GITHUB_API_URL"],
+  })
+).catch((error) => {
+  console.error(error);
+  core.setFailed(error.message);
+});

--- a/post.js
+++ b/post.js
@@ -5,9 +5,12 @@ import { request } from "@octokit/request";
 
 import { post } from "./lib/post.js";
 
-post(core, request).catch(
-  (error) => {
-    console.error(error);
-    core.setFailed(error.message);
-  }
-);
+post(
+  core,
+  request.defaults({
+    baseUrl: process.env["GITHUB_API_URL"],
+  })
+).catch((error) => {
+  console.error(error);
+  core.setFailed(error.message);
+});


### PR DESCRIPTION
This adds support for this action to be used in GitHub Enterprise Server.
It sends request to the base url extracted from [GITHUB_API_URL](https://docs.github.com/en/enterprise-server@3.10/actions/learn-github-actions/variables#default-environment-variables).