### PR TITLE
docs: update `skip-token-revoke` input name

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The action creates an installation access token using [the `POST /app/installati
 1. The token is scoped to the current repository or `repositories` if set.
 2. The token inherits all the installation's permissions.
 3. The token is set as output `token` which can be used in subsequent steps.
-4. Unless the `skip_token_revoke` input is set to a truthy value, the token is revoked in the `post` step of the action, which means it cannot be passed to another job.
+4. Unless the `skip-token-revoke` input is set to a truthy value, the token is revoked in the `post` step of the action, which means it cannot be passed to another job.
 5. The token is masked, it cannot be logged accidentally.
 
 > [!NOTE]


### PR DESCRIPTION
This is a quick follow-up to #59. I was mid-review when it merged and noticed one instance of `skip_token_revoke` in the README that didn't get changed to `skip-token-revoke`. The PR merged just before I pushed a commit to fix it. 