### PR TITLE
docs(README): fix use of deprecated arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ jobs:
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
-          app_id: ${{ vars.APP_ID }}
-          private_key: ${{ secrets.PRIVATE_KEY }}
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
           owner: ${{ matrix.owners-and-repos.owner }}
           repositories: ${{ join(matrix.owners-and-repos.repos) }}
       - uses: octokit/request-action@v2.x


### PR DESCRIPTION
Using those fields that have an underscore (instead of a hyphen) cause the following warnings if used:
```
Warning: Input 'app_id' has been deprecated with message: 'app_id' is deprecated and will be removed in a future version. Use 'app-id' instead.
Warning: Input 'private_key' has been deprecated with message: 'private_key' is deprecated and will be removed in a future version. Use 'private-key' instead.
```

So this PR just drops the last use of `app_id` and `private_key` from the README in favor of `app-id` and `private-key`.