### PR TITLE
fix: handle clock skew

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -70,15 +70,11 @@ export async function main(
     request,
   });
 
-  const appAuthentication = await auth({
-    type: "app",
-  });
-
   let authentication;
   // If at least one repository is set, get installation ID from that repository
 
   if (parsedRepositoryNames) {
-    authentication = await pRetry(() => getTokenFromRepository(request, auth, parsedOwner,appAuthentication, parsedRepositoryNames), {
+    authentication = await pRetry(() => getTokenFromRepository(request, auth, parsedOwner, parsedRepositoryNames), {
       onFailedAttempt: (error) => {
         core.info(
           `Failed to create token for "${parsedRepositoryNames}" (attempt ${error.attemptNumber}): ${error.message}`
@@ -89,7 +85,7 @@ export async function main(
 
   } else {
     // Otherwise get the installation for the owner, which can either be an organization or a user account
-    authentication = await pRetry(() => getTokenFromOwner(request, auth, appAuthentication, parsedOwner), {
+    authentication = await pRetry(() => getTokenFromOwner(request, auth, parsedOwner), {
       onFailedAttempt: (error) => {
         core.info(
           `Failed to create token for "${parsedOwner}" (attempt ${error.attemptNumber}): ${error.message}`
@@ -110,12 +106,12 @@ export async function main(
   }
 }
 
-async function getTokenFromOwner(request, auth, appAuthentication, parsedOwner) {
+async function getTokenFromOwner(request, auth, parsedOwner) {
   // https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-organization-installation-for-the-authenticated-app
   const response = await request("GET /orgs/{org}/installation", {
     org: parsedOwner,
-    headers: {
-      authorization: `bearer ${appAuthentication.token}`,
+    request: {
+      hook: auth.hook,
     },
   }).catch((error) => {
     /* c8 ignore next */
@@ -124,8 +120,8 @@ async function getTokenFromOwner(request, auth, appAuthentication, parsedOwner) 
     // https://docs.github.com/rest/apps/apps?apiVersion=2022-11-28#get-a-user-installation-for-the-authenticated-app
     return request("GET /users/{username}/installation", {
       username: parsedOwner,
-      headers: {
-        authorization: `bearer ${appAuthentication.token}`,
+      request: {
+        hook: auth.hook,
       },
     });
   });
@@ -138,13 +134,13 @@ async function getTokenFromOwner(request, auth, appAuthentication, parsedOwner) 
   return authentication;
 }
 
-async function getTokenFromRepository(request, auth, parsedOwner,appAuthentication, parsedRepositoryNames) {
+async function getTokenFromRepository(request, auth, parsedOwner, parsedRepositoryNames) {
   // https://docs.github.com/rest/apps/apps?apiVersion=2022-11-28#get-a-repository-installation-for-the-authenticated-app
   const response = await request("GET /repos/{owner}/{repo}/installation", {
     owner: parsedOwner,
     repo: parsedRepositoryNames.split(",")[0],
-    headers: {
-      authorization: `bearer ${appAuthentication.token}`,
+    request: {
+      hook: auth.hook,
     },
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-github-app-token",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-github-app-token",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",
@@ -15,6 +15,7 @@
         "p-retry": "^6.1.0"
       },
       "devDependencies": {
+        "@sinonjs/fake-timers": "^11.2.2",
         "ava": "^5.3.1",
         "c8": "^8.0.1",
         "dotenv": "^16.3.1",
@@ -809,6 +810,24 @@
       "integrity": "sha512-EzD434aHTFifGudYAygnFlS1Tl6KhbTynEWELQXIbTY8Msvb5nEqTZIm7sbPEt4mQYLZwu3zPKVdeIrw0g7ovg==",
       "dependencies": {
         "@octokit/openapi-types": "^19.0.0"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
       }
     },
     "node_modules/@tokenizer/token": {
@@ -4087,6 +4106,15 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "p-retry": "^6.1.0"
   },
   "devDependencies": {
+    "@sinonjs/fake-timers": "^11.2.2",
     "ava": "^5.3.1",
     "c8": "^8.0.1",
     "dotenv": "^16.3.1",

--- a/tests/main-repo-skew.js
+++ b/tests/main-repo-skew.js
@@ -1,0 +1,56 @@
+import { test } from "./main.js";
+
+import { install } from "@sinonjs/fake-timers";
+
+// Verify `main` retry when the clock has drifted.
+await test((mockPool) => {
+  process.env.INPUT_OWNER = 'actions'
+  process.env.INPUT_REPOSITORIES = 'failed-repo';
+  const owner = process.env.INPUT_OWNER
+  const repo = process.env.INPUT_REPOSITORIES
+  const mockInstallationId = "123456";
+
+  install({ now: 0, toFake: ["Date"] });
+
+  mockPool
+    .intercept({
+      path: `/repos/${owner}/${repo}/installation`,
+      method: "GET",
+      headers: {
+        accept: "application/vnd.github.v3+json",
+        "user-agent": "actions/create-github-app-token",
+        // Intentionally omitting the `authorization` header, since JWT creation is not idempotent.
+      },
+    })
+    .reply(({ headers }) => {
+      const [_, jwt] = (headers.authorization || "").split(" ");
+      const payload = JSON.parse(Buffer.from(jwt.split(".")[1], "base64").toString());
+
+      if (payload.iat < 0) {
+        return {
+          statusCode: 401,
+          data: {
+            message: "'Issued at' claim ('iat') must be an Integer representing the time that the assertion was issued."
+          },
+          responseOptions: {
+            headers: {
+              "content-type": "application/json",
+              "date": new Date(Date.now() + 30000).toUTCString()
+            }
+          }
+        };
+      }
+
+      return {
+        statusCode: 200,
+        data: {
+          id: mockInstallationId
+        },
+        responseOptions: {
+          headers: {
+            "content-type": "application/json"
+          }
+        }
+      };
+    }).times(2);
+});


### PR DESCRIPTION
GitHub's macOS runners for the past while have had some bad clock drift which sometimes prevents this action from working with the error:

```console
'Issued at' claim ('iat') must be an Integer representing the time that the assertion was issued
```

`@octokit/auth-app` already has logic to handle this so we can defer to that code.