### PR TITLE
docs(README): add GHES workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ jobs:
         app-id: ${{ vars.GHES_APP_ID }}
         private-key: ${{ secrets.GHES_APP_PRIVATE_KEY }}
         owner: ${{ vars.GHES_INSTALLATION_ORG }}
-        github-api-url: ${{ vars.GHES_GITHUB_API_URL }}
+        github-api-url: ${{ vars.GITHUB_API_URL }}
 
     - name: Create issue
       uses: octokit/request-action@v2.x

--- a/README.md
+++ b/README.md
@@ -179,6 +179,32 @@ jobs:
 
 ```yaml
 on: [push]
+
+jobs:
+  create_issue:
+    runs-on: self-hosted
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Create GitHub App Token
+      id: create_token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.GHES_APP_ID }}
+        private-key: ${{ secrets.GHES_APP_PRIVATE_KEY }}
+        owner: ${{ secrets.GHES_INSTALLATION_ORG }}
+        github-api-url: ${{ secrets.GHES_GITHUB_API_URL }}
+
+    - name: Create issue
+      uses: octokit/request-action@v2.x
+      with:
+        route: POST /repos/${{ github.repository }}/issues
+        title: "New issue from workflow"
+        body: "This is a new issue created from a GitHub Action workflow."
+      env:
+        GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
 ```
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -185,9 +185,6 @@ jobs:
     runs-on: self-hosted
 
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Create GitHub App Token
       id: create_token
       uses: actions/create-github-app-token@v1

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ jobs:
     runs-on: self-hosted
 
     steps:
-    - name: Create GitHub App Token
+    - name: Create GitHub App token
       id: create_token
       uses: actions/create-github-app-token@v1
       with:

--- a/README.md
+++ b/README.md
@@ -192,10 +192,10 @@ jobs:
       id: create_token
       uses: actions/create-github-app-token@v1
       with:
-        app-id: ${{ secrets.GHES_APP_ID }}
+        app-id: ${{ vars.GHES_APP_ID }}
         private-key: ${{ secrets.GHES_APP_PRIVATE_KEY }}
-        owner: ${{ secrets.GHES_INSTALLATION_ORG }}
-        github-api-url: ${{ secrets.GHES_GITHUB_API_URL }}
+        owner: ${{ vars.GHES_INSTALLATION_ORG }}
+        github-api-url: ${{ vars.GHES_GITHUB_API_URL }}
 
     - name: Create issue
       uses: octokit/request-action@v2.x


### PR DESCRIPTION
This pull request includes a significant change to the `README.md` file. The change adds a new job to the GitHub Actions workflow, which is designed to create an example of how to use `create-github-app-token` action on GitHub Enterprise Server.

Resolves https://github.com/actions/create-github-app-token/issues/98