### PR TITLE
fix: clarify `owner` input description

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ jobs:
 
 ### `owner`
 
-**Optional:** GitHub App installation owner. If empty, defaults to the current repository owner.
+**Optional:** The owner of the GitHub App installation. If empty, defaults to the current repository owner.
 
 ### `repositories`
 

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     deprecationMessage: "'private_key' is deprecated and will be removed in a future version. Use 'private-key' instead."
   owner:
-    description: "GitHub App owner (defaults to current repository owner)"
+    description: "The owner of the GitHub App installation (defaults to current repository owner)"
     required: false
   repositories:
     description: "Repositories to install the GitHub App on (defaults to current repository if owner is unset)"


### PR DESCRIPTION
Clarify the purpose of the `owner` input.

Resolves #116.
