### PR TITLE
Feature - Adding App Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,20 @@ jobs:
 
 **Required:** GitHub App private key.
 
+### `app-settings`
+
+***Optional:** GitHub App settings.
+
+A JSON object containing the GitHub App ID and private key. If `app-id` and `private-key` are set, this input will be ignored.
+
+```json
+{ "app-id": "", "private-key": "" }
+```
+Command to copy private key to clipboard on a single line:
+```bash
+awk -v ORS='\\n' '1' private-key.pem | pbcopy
+```
+
 ### `owner`
 
 **Optional:** The owner of the GitHub App installation. If empty, defaults to the current repository owner.

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
     description: "GitHub App ID"
     required: false
     deprecationMessage: "'app_id' is deprecated and will be removed in a future version. Use 'app-id' instead."
+  app-settings:
+    description: "GitHub App settings"
+    required: false
   private-key:
     description: "GitHub App private key"
     required: false # TODO: When 'private_key' is removed, make 'private-key' required

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -30052,13 +30052,27 @@ if (!process.env.GITHUB_REPOSITORY) {
 if (!process.env.GITHUB_REPOSITORY_OWNER) {
   throw new Error("GITHUB_REPOSITORY_OWNER missing, must be set to '<owner>'");
 }
-var appId = import_core2.default.getInput("app-id") || import_core2.default.getInput("app_id");
-if (!appId) {
-  throw new Error("Input required and not supplied: app-id");
-}
-var privateKey = import_core2.default.getInput("private-key") || import_core2.default.getInput("private_key");
-if (!privateKey) {
-  throw new Error("Input required and not supplied: private-key");
+var appSettings = import_core2.default.getInput("app-settings");
+var appId;
+var privateKey;
+
+if (appSettings) {
+  appSettings = JSON.parse(appSettings);
+  if (!appSettings['app-id'] || !appSettings['private-key']) {
+    throw new Error("app-settings must contain valid app_id and private_key fields");
+  }
+  appId = appSettings['app-id'];
+  privateKey = appSettings['private-key'];
+} else {
+  appId = import_core2.default.getInput("app-id") || import_core2.default.getInput("app_id");
+  if (!appId) {
+    throw new Error("Input required and not supplied: app-id");
+  }
+
+  privateKey = import_core2.default.getInput("private-key") || import_core2.default.getInput("private_key");
+  if (!privateKey) {
+    throw new Error("Input required and not supplied: private-key");
+  }
 }
 var owner = import_core2.default.getInput("owner");
 var repositories = import_core2.default.getInput("repositories");

--- a/main.js
+++ b/main.js
@@ -14,15 +14,28 @@ if (!process.env.GITHUB_REPOSITORY_OWNER) {
   throw new Error("GITHUB_REPOSITORY_OWNER missing, must be set to '<owner>'");
 }
 
-const appId = core.getInput("app-id") || core.getInput("app_id");
-if (!appId) {
-  // The 'app_id' input was previously required, but it and 'app-id' are both optional now, until the former is removed. Still, we want to ensure that at least one of them is set.
-  throw new Error("Input required and not supplied: app-id");
-}
-const privateKey = core.getInput("private-key") || core.getInput("private_key");
-if (!privateKey) {
-  // The 'private_key' input was previously required, but it and 'private-key' are both optional now, until the former is removed. Still, we want to ensure that at least one of them is set.
-  throw new Error("Input required and not supplied: private-key");
+let appSettings = core.getInput("app-settings");
+
+let appId;
+let privateKey;
+
+if (appSettings) {
+  appSettings = JSON.parse(appSettings);
+  if (!appSettings['app-id'] || !appSettings['private-key']) {
+    throw new Error("app-settings must contain valid app_id and private_key fields");
+  }
+  appId = appSettings['app-id'];
+  privateKey = appSettings['private-key'];
+} else {
+  appId = core.getInput("app-id") || core.getInput("app_id");
+  if (!appId) {
+    throw new Error("Input required and not supplied: app-id");
+  }
+
+  privateKey = core.getInput("private-key") || core.getInput("private_key");
+  if (!privateKey) {
+    throw new Error("Input required and not supplied: private-key");
+  }
 }
 const owner = core.getInput("owner");
 const repositories = core.getInput("repositories");


### PR DESCRIPTION
In the context of larger organizations where organization-wide secrets are preferred over repository-specific secrets, the current requirement of managing two secrets per application can lead to substantial overhead. To alleviate this, the proposed change offers an option to consolidate all inputs into a single secret.

This approach potentially simplifies secret management significantly, reducing the total number of secrets that need to be maintained. Though it's uncertain whether this function will be appreciated or useful to all users, the aim of this pull request is to initiate a discussion regarding its potential benefits and drawbacks.