### PR TITLE
add compiled credentials to outputs

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -100,6 +100,7 @@ export async function main(
   core.setOutput("token", authentication.token);
   core.setOutput("installation-id", installationId);
   core.setOutput("app-slug", appSlug);
+  core.setOutput("commiter", `${appSlug}[bot] <${installationId}+${appSlug}[bot]@users.noreply.github.com>`);
 
   // Make token accessible to post function (so we can invalidate it)
   if (!skipTokenRevoke) {


### PR DESCRIPTION
This is the iteration of #105

I'd like to have compiled credentials as an output. I'm not sure about commiter, it's just how I'll be using it. Perhaps credentials is a better name?

My use case is that the following quite lengthy:

```
  - uses: org/gitops@v2
    with:
      github-token: ${{ steps.app-auth.outputs.token }}
      repo: gitops-repo
      commiter: "${{steps.app-auth.outputs.app-slug}}[bot] <${{ steps.app-auth.outputs.installation-id }}+${{ steps.app-auth.outputs.app-slug }}[bot]@users.noreply.github.com"
```

And I'd like to use something less verbose, like this:
```
  - uses: org/gitops@v2
    with:
      github-token: ${{ steps.app-auth.outputs.token }}
      repo: gcp-domain-name
      commiter: "${{ steps.app-auth.outputs.credentials }}"
```


Im going to use this credentials as a commiter value for the gitops commits, while keeping the author as pull-request authors

What do you think of this idea? Are you open to this addition? if you are open to the idea and credentials is acceptable name, I will update docs and test to finalise the pull-request