### PR TITLE
Add built-in support for basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,14 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: peter-evans/create-or-update-comment@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
-          issue-number: ${{ github.event.issue.number }}
-          body: "Hello, World!"
+          ref: ${{ github.head_ref }}
+          # Access allowed to private submodules in the current owner's installation
+          submodules: recursive
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
 ```
 
 ### Create a token for multiple repositories in the current owner's installation

--- a/README.md
+++ b/README.md
@@ -109,6 +109,29 @@ jobs:
           persist-credentials: false
 ```
 
+### Use token for all repositories in the current owner's installation, encoded for http basic auth
+
+```yaml
+on: [pull_request]
+
+jobs:
+  auto-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: http.https://github.com/.extraheader
+          GIT_CONFIG_VALUE_0: "AUTHORIZATION: basic ${{ steps.app-token.outputs.basic-auth-credentials }}"
+        # Access allowed to private submodules in the current owner's installation
+        run: git clone --recurse-submodules --shallow-submodules https://github.com/${{ github.repository }}
+```
+
 ### Create a token for multiple repositories in the current owner's installation
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,8 @@ inputs:
 outputs:
   token:
     description: "GitHub installation access token"
+  basic-auth-credentials:
+    description: "HTTP basic auth credentials using the access token"
   installation-id:
     description: "GitHub App installation ID"
   app-slug:

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -39747,8 +39747,11 @@ async function main(appId2, privateKey2, owner2, repositories2, core3, createApp
       retries: 3
     }));
   }
+  let basicAuthCredentials = btoa("x-access-token:" + authentication.token);
   core3.setSecret(authentication.token);
+  core3.setSecret(basicAuthCredentials);
   core3.setOutput("token", authentication.token);
+  core3.setOutput("basic-auth-credentials", basicAuthCredentials);
   core3.setOutput("installation-id", installationId);
   core3.setOutput("app-slug", appSlug);
   if (!skipTokenRevoke2) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -94,10 +94,14 @@ export async function main(
     }));
   }
 
+  let basicAuthCredentials = btoa("x-access-token:" + authentication.token)
+
   // Register the token with the runner as a secret to ensure it is masked in logs
   core.setSecret(authentication.token);
+  core.setSecret(basicAuthCredentials);
 
   core.setOutput("token", authentication.token);
+  core.setOutput("basic-auth-credentials", basicAuthCredentials);
   core.setOutput("installation-id", installationId);
   core.setOutput("app-slug", appSlug);
 


### PR DESCRIPTION
This allows using the encoded token for basic auth-based git access.

This is useful for scripts expecting to be able to access private git repos. My specific case was using [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) in a repo that brings in other private repos as dependencies.

While the encoding to make this work is very simple, the documentation for it is sparse and it is not trivial to figure out, so there's value in providing this out of the box.