### PR TITLE
docs(README): fix the `git committer string` and `Configure git CLI` examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ jobs:
 > 
 > For example, we can check at `https://api.github.com/users/dependabot[bot]` to see the user ID of Dependabot is 49699333.
 >
-> Similarly to get the id, you can also use the [octokit/request-action](https://github.com/octokit/request-action).
+> Alternatively, you can use the [octokit/request-action](https://github.com/octokit/request-action) to get the ID.
 
 ### Create a token for all repositories in the current owner's installation
 

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ jobs:
           # required
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
-      - name: Retrieve GitHub App User ID
+      - name: Get GitHub App User ID
         id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.generate-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - id: committer
-        run: echo "string=${{steps.app-token.outputs.app-slug}}[bot] <${{steps.get-user-id.outputs.user-id}}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>"  >> "$GITHUB_OUTPUT"
-      - run: echo "committer string is ${{steps.committer.outputs.string}}"
+        run: echo "string=${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>"  >> "$GITHUB_OUTPUT"
+      - run: echo "committer string is ${ {steps.committer.outputs.string }}"
 ```
 
 ### Configure git CLI for an app's bot user
@@ -104,14 +104,14 @@ jobs:
           # required
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
-      - name: Retrieve GitHub App User ID
+      - name: Get GitHub App User ID
         id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.generate-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - run: |
-          git config --global user.name '${{steps.app-token.outputs.app-slug}}[bot]'
-          git config --global user.email '${{steps.get-user-id.outputs.user-id}}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
       # git commands like commit work using the bot user
       - run: |
           git add .
@@ -119,8 +119,12 @@ jobs:
           git push
 ```
 
-The `<BOT USER ID>` is the numeric user ID of the app's bot user, which can be found under `https://api.github.com/users/<app-slug>%5Bbot%5D`.
-For example, we can check at `https://api.github.com/users/dependabot%5Bbot%5D` to see the user ID of dependabot is 49699333.
+> [!TIP]
+> The `<BOT USER ID>` is the numeric user ID of the app's bot user, which can be found under `https://api.github.com/users/<app-slug>%5Bbot%5D`.
+> 
+> For example, we can check at `https://api.github.com/users/dependabot%5Bbot%5D` to see the user ID of dependabot is 49699333.
+>
+> Similarly to get the id, you can also use the [octokit/request-action](https://github.com/octokit/request-action).
 
 ### Create a token for all repositories in the current owner's installation
 
@@ -203,7 +207,7 @@ jobs:
   set-matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{steps.set.outputs.matrix }}
+      matrix: ${{ steps.set.outputs.matrix }}
     steps:
       - id: set
         run: echo 'matrix=[{"owner":"owner1"},{"owner":"owner2","repos":["repo1"]}]' >>"$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ jobs:
 > [!TIP]
 > The `<BOT USER ID>` is the numeric user ID of the app's bot user, which can be found under `https://api.github.com/users/<app-slug>%5Bbot%5D`.
 > 
-> For example, we can check at `https://api.github.com/users/dependabot%5Bbot%5D` to see the user ID of dependabot is 49699333.
+> For example, we can check at `https://api.github.com/users/dependabot[bot]` to see the user ID of Dependabot is 49699333.
 >
 > Similarly to get the id, you can also use the [octokit/request-action](https://github.com/octokit/request-action).
 


### PR DESCRIPTION
1. Fix the `git committer string` and `Configure git CLI` examples.
2. Formatting examples
3. Modify the get `<BOT USER ID>` comment and add a note that [octokit/request-action](https://github.com/octokit/request-action) can be used.