### PR TITLE
Add scoped tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,36 @@ jobs:
         GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}
 ```
 
+### Creating a scoped token
+
+A GitHub App can [create](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-a-scoped-access-token) a scoped token, a token with a subset of permissions assigned to the GitHub App.
+
+This allows you to apply the principle of least privilege to the token, but doesn't protect you against malicious code running in your workflow because that can directly access the private key used to generate the token.
+
+```yaml
+name: Run tests on staging
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  hello-world:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          permissions: |
+            metadata: read
+            contents: write
+      - uses: ./actions/staging-tests
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+```
+
 ## Inputs
 
 ### `app-id`
@@ -328,6 +358,11 @@ GitHub App installation ID.
 ### `app-slug`
 
 GitHub App slug.
+
+### `permissions`
+
+**Optional:** A comma-separate or newline-separate list of permissions for the scoped token.
+See the `properties` object description in the [create-a-scoped-access-token](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-a-scoped-access-token) documentation for the supported permissions.
 
 ## How it works
 

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
   github-api-url:
     description: The URL of the GitHub REST API.
     default: ${{ github.api_url }}
+  permissions:
+    description: "A comma or newline seperated list of permissions to scope the token."
+    required: false
 outputs:
   token:
     description: "GitHub installation access token"

--- a/dist/post.cjs
+++ b/dist/post.cjs
@@ -19943,6 +19943,27 @@ var require_util8 = __commonJS({
     }
     var kEnumerableProperty = /* @__PURE__ */ Object.create(null);
     kEnumerableProperty.enumerable = true;
+    var normalizedMethodRecordsBase = {
+      delete: "DELETE",
+      DELETE: "DELETE",
+      get: "GET",
+      GET: "GET",
+      head: "HEAD",
+      HEAD: "HEAD",
+      options: "OPTIONS",
+      OPTIONS: "OPTIONS",
+      post: "POST",
+      POST: "POST",
+      put: "PUT",
+      PUT: "PUT"
+    };
+    var normalizedMethodRecords = {
+      ...normalizedMethodRecordsBase,
+      patch: "patch",
+      PATCH: "PATCH"
+    };
+    Object.setPrototypeOf(normalizedMethodRecordsBase, null);
+    Object.setPrototypeOf(normalizedMethodRecords, null);
     module2.exports = {
       kEnumerableProperty,
       nop,
@@ -19981,6 +20002,8 @@ var require_util8 = __commonJS({
       isValidHeaderValue,
       isTokenCharCode,
       parseRangeHeader,
+      normalizedMethodRecordsBase,
+      normalizedMethodRecords,
       isValidPort,
       isHttpOrHttpsPrefixed,
       nodeMajor,
@@ -20196,7 +20219,8 @@ var require_request3 = __commonJS({
       isBlobLike,
       buildURL,
       validateHandler,
-      getServerName
+      getServerName,
+      normalizedMethodRecords
     } = require_util8();
     var { channels } = require_diagnostics();
     var { headerNameLowerCasedRecord } = require_constants6();
@@ -20223,12 +20247,12 @@ var require_request3 = __commonJS({
           throw new InvalidArgumentError("path must be a string");
         } else if (path[0] !== "/" && !(path.startsWith("http://") || path.startsWith("https://")) && method !== "CONNECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.exec(path) !== null) {
+        } else if (invalidPathRegex.test(path)) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
           throw new InvalidArgumentError("method must be a string");
-        } else if (!isValidHTTPToken(method)) {
+        } else if (normalizedMethodRecords[method] === void 0 && !isValidHTTPToken(method)) {
           throw new InvalidArgumentError("invalid request method");
         }
         if (upgrade && typeof upgrade !== "string") {
@@ -20773,7 +20797,7 @@ var require_connect2 = __commonJS({
         }
       };
     }
-    function buildConnector({ allowH2, maxCachedSessions, socketPath, timeout, ...opts }) {
+    function buildConnector({ allowH2, maxCachedSessions, socketPath, timeout, session: customSession, ...opts }) {
       if (maxCachedSessions != null && (!Number.isInteger(maxCachedSessions) || maxCachedSessions < 0)) {
         throw new InvalidArgumentError("maxCachedSessions must be a positive integer or zero");
       }
@@ -20789,7 +20813,7 @@ var require_connect2 = __commonJS({
           }
           servername = servername || options.servername || util.getServerName(host) || null;
           const sessionKey = servername || hostname;
-          const session = sessionCache.get(sessionKey) || null;
+          const session = customSession || sessionCache.get(sessionKey) || null;
           assert(sessionKey);
           socket = tls.connect({
             highWaterMark: 16384,
@@ -22307,7 +22331,7 @@ var require_util9 = __commonJS({
     var { getGlobalOrigin } = require_global3();
     var { collectASequenceOfCodePoints, collectAnHTTPQuotedString, removeChars, parseMIMEType } = require_data_url();
     var { performance: performance2 } = require("node:perf_hooks");
-    var { isBlobLike, ReadableStreamFrom, isValidHTTPToken } = require_util8();
+    var { isBlobLike, ReadableStreamFrom, isValidHTTPToken, normalizedMethodRecordsBase } = require_util8();
     var assert = require("node:assert");
     var { isUint8Array } = require("node:util/types");
     var { webidl } = require_webidl2();
@@ -22414,7 +22438,7 @@ var require_util9 = __commonJS({
     }
     function appendRequestOriginHeader(request2) {
       let serializedOrigin = request2.origin;
-      if (serializedOrigin === "client") {
+      if (serializedOrigin === "client" || serializedOrigin === void 0) {
         return;
       }
       if (request2.responseTainting === "cors" || request2.mode === "websocket") {
@@ -22695,29 +22719,8 @@ var require_util9 = __commonJS({
     function isCancelled(fetchParams) {
       return fetchParams.controller.state === "aborted" || fetchParams.controller.state === "terminated";
     }
-    var normalizeMethodRecordBase = {
-      delete: "DELETE",
-      DELETE: "DELETE",
-      get: "GET",
-      GET: "GET",
-      head: "HEAD",
-      HEAD: "HEAD",
-      options: "OPTIONS",
-      OPTIONS: "OPTIONS",
-      post: "POST",
-      POST: "POST",
-      put: "PUT",
-      PUT: "PUT"
-    };
-    var normalizeMethodRecord = {
-      ...normalizeMethodRecordBase,
-      patch: "patch",
-      PATCH: "PATCH"
-    };
-    Object.setPrototypeOf(normalizeMethodRecordBase, null);
-    Object.setPrototypeOf(normalizeMethodRecord, null);
     function normalizeMethod(method) {
-      return normalizeMethodRecordBase[method.toLowerCase()] ?? method;
+      return normalizedMethodRecordsBase[method.toLowerCase()] ?? method;
     }
     function serializeJavascriptValueToJSONString(value) {
       const result = JSON.stringify(value);
@@ -22854,7 +22857,7 @@ var require_util9 = __commonJS({
         }
       });
     }
-    async function fullyReadBody(body, processBody, processBodyError, shouldClone) {
+    async function fullyReadBody(body, processBody, processBodyError) {
       const successSteps = processBody;
       const errorSteps = processBodyError;
       let reader;
@@ -22865,7 +22868,7 @@ var require_util9 = __commonJS({
         return;
       }
       try {
-        successSteps(await readAllBytes(reader, shouldClone));
+        successSteps(await readAllBytes(reader));
       } catch (e) {
         errorSteps(e);
       }
@@ -22888,19 +22891,12 @@ var require_util9 = __commonJS({
       assert(!invalidIsomorphicEncodeValueRegex.test(input));
       return input;
     }
-    async function readAllBytes(reader, shouldClone) {
+    async function readAllBytes(reader) {
       const bytes = [];
       let byteLength = 0;
       while (true) {
         const { done, value: chunk } = await reader.read();
         if (done) {
-          if (bytes.length === 1) {
-            const { buffer, byteOffset, byteLength: byteLength2 } = bytes[0];
-            if (shouldClone === false) {
-              return Buffer.from(buffer, byteOffset, byteLength2);
-            }
-            return Buffer.from(buffer.slice(byteOffset, byteOffset + byteLength2), 0, byteLength2);
-          }
           return Buffer.concat(bytes, byteLength);
         }
         if (!isUint8Array(chunk)) {
@@ -23163,7 +23159,6 @@ var require_util9 = __commonJS({
       urlHasHttpsScheme,
       urlIsHttpHttpsScheme,
       readAllBytes,
-      normalizeMethodRecord,
       simpleRangeHeaderValue,
       buildContentRange,
       parseMetadata,
@@ -23835,18 +23830,18 @@ Content-Type: ${value.type || "application/octet-stream"}\r
               mimeType = serializeAMimeType(mimeType);
             }
             return new Blob2([bytes], { type: mimeType });
-          }, instance, false);
+          }, instance);
         },
         arrayBuffer() {
           return consumeBody(this, (bytes) => {
-            return bytes.buffer;
-          }, instance, true);
+            return new Uint8Array(bytes).buffer;
+          }, instance);
         },
         text() {
-          return consumeBody(this, utf8DecodeBytes, instance, false);
+          return consumeBody(this, utf8DecodeBytes, instance);
         },
         json() {
-          return consumeBody(this, parseJSONFromBytes, instance, false);
+          return consumeBody(this, parseJSONFromBytes, instance);
         },
         formData() {
           return consumeBody(this, (value) => {
@@ -23875,12 +23870,12 @@ Content-Type: ${value.type || "application/octet-stream"}\r
             throw new TypeError(
               'Content-Type was not one of "multipart/form-data" or "application/x-www-form-urlencoded".'
             );
-          }, instance, false);
+          }, instance);
         },
         bytes() {
           return consumeBody(this, (bytes) => {
-            return new Uint8Array(bytes.buffer, 0, bytes.byteLength);
-          }, instance, true);
+            return new Uint8Array(bytes);
+          }, instance);
         }
       };
       return methods;
@@ -23888,7 +23883,7 @@ Content-Type: ${value.type || "application/octet-stream"}\r
     function mixinBody(prototype) {
       Object.assign(prototype.prototype, bodyMixinMethods(prototype));
     }
-    async function consumeBody(object, convertBytesToJSValue, instance, shouldClone) {
+    async function consumeBody(object, convertBytesToJSValue, instance) {
       webidl.brandCheck(object, instance);
       if (bodyUnusable(object[kState].body)) {
         throw new TypeError("Body is unusable: Body has already been read");
@@ -23907,7 +23902,7 @@ Content-Type: ${value.type || "application/octet-stream"}\r
         successSteps(Buffer.allocUnsafe(0));
         return promise.promise;
       }
-      await fullyReadBody(object[kState].body, successSteps, errorSteps, shouldClone);
+      await fullyReadBody(object[kState].body, successSteps, errorSteps);
       return promise.promise;
     }
     function bodyUnusable(body) {
@@ -24660,25 +24655,25 @@ upgrade: ${upgrade}\r
         channels.sendHeaders.publish({ request: request2, headers: header, socket });
       }
       if (!body || bodyLength === 0) {
-        writeBuffer({ abort, body: null, client, request: request2, socket, contentLength, header, expectsPayload });
+        writeBuffer(abort, null, client, request2, socket, contentLength, header, expectsPayload);
       } else if (util.isBuffer(body)) {
-        writeBuffer({ abort, body, client, request: request2, socket, contentLength, header, expectsPayload });
+        writeBuffer(abort, body, client, request2, socket, contentLength, header, expectsPayload);
       } else if (util.isBlobLike(body)) {
         if (typeof body.stream === "function") {
-          writeIterable({ abort, body: body.stream(), client, request: request2, socket, contentLength, header, expectsPayload });
+          writeIterable(abort, body.stream(), client, request2, socket, contentLength, header, expectsPayload);
         } else {
-          writeBlob({ abort, body, client, request: request2, socket, contentLength, header, expectsPayload });
+          writeBlob(abort, body, client, request2, socket, contentLength, header, expectsPayload);
         }
       } else if (util.isStream(body)) {
-        writeStream({ abort, body, client, request: request2, socket, contentLength, header, expectsPayload });
+        writeStream(abort, body, client, request2, socket, contentLength, header, expectsPayload);
       } else if (util.isIterable(body)) {
-        writeIterable({ abort, body, client, request: request2, socket, contentLength, header, expectsPayload });
+        writeIterable(abort, body, client, request2, socket, contentLength, header, expectsPayload);
       } else {
         assert(false);
       }
       return true;
     }
-    function writeStream({ abort, body, client, request: request2, socket, contentLength, header, expectsPayload }) {
+    function writeStream(abort, body, client, request2, socket, contentLength, header, expectsPayload) {
       assert(contentLength !== 0 || client[kRunning] === 0, "stream body cannot be pipelined");
       let finished = false;
       const writer = new AsyncWriter({ abort, socket, request: request2, contentLength, client, expectsPayload, header });
@@ -24747,7 +24742,7 @@ upgrade: ${upgrade}\r
         setImmediate(onClose);
       }
     }
-    function writeBuffer({ abort, body, client, request: request2, socket, contentLength, header, expectsPayload }) {
+    function writeBuffer(abort, body, client, request2, socket, contentLength, header, expectsPayload) {
       try {
         if (!body) {
           if (contentLength === 0) {
@@ -24778,7 +24773,7 @@ upgrade: ${upgrade}\r
         abort(err);
       }
     }
-    async function writeBlob({ abort, body, client, request: request2, socket, contentLength, header, expectsPayload }) {
+    async function writeBlob(abort, body, client, request2, socket, contentLength, header, expectsPayload) {
       assert(contentLength === body.size, "blob body must have content length");
       try {
         if (contentLength != null && contentLength !== body.size) {
@@ -24801,7 +24796,7 @@ upgrade: ${upgrade}\r
         abort(err);
       }
     }
-    async function writeIterable({ abort, body, client, request: request2, socket, contentLength, header, expectsPayload }) {
+    async function writeIterable(abort, body, client, request2, socket, contentLength, header, expectsPayload) {
       assert(contentLength !== 0 || client[kRunning] === 0, "iterator body cannot be pipelined");
       let callback = null;
       function onDrain() {
@@ -25264,81 +25259,79 @@ var require_client_h2 = __commonJS({
       return true;
       function writeBodyH2() {
         if (!body || contentLength === 0) {
-          writeBuffer({
+          writeBuffer(
             abort,
+            stream,
+            null,
             client,
-            request: request2,
+            request2,
+            client[kSocket],
             contentLength,
-            expectsPayload,
-            h2stream: stream,
-            body: null,
-            socket: client[kSocket]
-          });
+            expectsPayload
+          );
         } else if (util.isBuffer(body)) {
-          writeBuffer({
+          writeBuffer(
             abort,
-            client,
-            request: request2,
-            contentLength,
+            stream,
             body,
-            expectsPayload,
-            h2stream: stream,
-            socket: client[kSocket]
-          });
+            client,
+            request2,
+            client[kSocket],
+            contentLength,
+            expectsPayload
+          );
         } else if (util.isBlobLike(body)) {
           if (typeof body.stream === "function") {
-            writeIterable({
+            writeIterable(
               abort,
+              stream,
+              body.stream(),
               client,
-              request: request2,
+              request2,
+              client[kSocket],
               contentLength,
-              expectsPayload,
-              h2stream: stream,
-              body: body.stream(),
-              socket: client[kSocket]
-            });
+              expectsPayload
+            );
           } else {
-            writeBlob({
+            writeBlob(
               abort,
+              stream,
               body,
               client,
-              request: request2,
+              request2,
+              client[kSocket],
               contentLength,
-              expectsPayload,
-              h2stream: stream,
-              socket: client[kSocket]
-            });
+              expectsPayload
+            );
           }
         } else if (util.isStream(body)) {
-          writeStream({
+          writeStream(
             abort,
+            client[kSocket],
+            expectsPayload,
+            stream,
             body,
             client,
-            request: request2,
-            contentLength,
-            expectsPayload,
-            socket: client[kSocket],
-            h2stream: stream,
-            header: ""
-          });
+            request2,
+            contentLength
+          );
         } else if (util.isIterable(body)) {
-          writeIterable({
+          writeIterable(
             abort,
+            stream,
             body,
             client,
-            request: request2,
+            request2,
+            client[kSocket],
             contentLength,
-            expectsPayload,
-            header: "",
-            h2stream: stream,
-            socket: client[kSocket]
-          });
+            expectsPayload
+          );
         } else {
           assert(false);
         }
       }
     }
-    function writeBuffer({ abort, h2stream, body, client, request: request2, socket, contentLength, expectsPayload }) {
+    function writeBuffer(abort, h2stream, body, client, request2, socket, contentLength, expectsPayload) {
       try {
         if (body != null && util.isBuffer(body)) {
           assert(contentLength === body.byteLength, "buffer body must have content length");
@@ -25357,7 +25350,7 @@ var require_client_h2 = __commonJS({
         abort(error);
       }
     }
-    function writeStream({ abort, socket, expectsPayload, h2stream, body, client, request: request2, contentLength }) {
+    function writeStream(abort, socket, expectsPayload, h2stream, body, client, request2, contentLength) {
       assert(contentLength !== 0 || client[kRunning] === 0, "stream body cannot be pipelined");
       const pipe = pipeline(
         body,
@@ -25381,7 +25374,7 @@ var require_client_h2 = __commonJS({
         request2.onBodySent(chunk);
       }
     }
-    async function writeBlob({ abort, h2stream, body, client, request: request2, socket, contentLength, expectsPayload }) {
+    async function writeBlob(abort, h2stream, body, client, request2, socket, contentLength, expectsPayload) {
       assert(contentLength === body.size, "blob body must have content length");
       try {
         if (contentLength != null && contentLength !== body.size) {
@@ -25402,7 +25395,7 @@ var require_client_h2 = __commonJS({
         abort(err);
       }
     }
-    async function writeIterable({ abort, h2stream, body, client, request: request2, socket, contentLength, expectsPayload }) {
+    async function writeIterable(abort, h2stream, body, client, request2, socket, contentLength, expectsPayload) {
       assert(contentLength !== 0 || client[kRunning] === 0, "iterator body cannot be pipelined");
       let callback = null;
       function onDrain() {
@@ -27147,7 +27140,7 @@ var require_retry_handler = __commonJS({
             this.abort(
               new RequestRetryError("Content-Range mismatch", statusCode, {
                 headers,
-                count: this.retryCount
+                data: { count: this.retryCount }
               })
             );
             return false;
@@ -27156,7 +27149,7 @@ var require_retry_handler = __commonJS({
             this.abort(
               new RequestRetryError("ETag mismatch", statusCode, {
                 headers,
-                count: this.retryCount
+                data: { count: this.retryCount }
               })
             );
             return false;
@@ -30380,9 +30373,7 @@ var require_request4 = __commonJS({
     var {
       isValidHTTPToken,
       sameOrigin,
-      normalizeMethod,
-      environmentSettingsObject,
-      normalizeMethodRecord
+      environmentSettingsObject
     } = require_util9();
     var {
       forbiddenMethodsSet,
@@ -30394,7 +30385,7 @@ var require_request4 = __commonJS({
       requestCache,
       requestDuplex
     } = require_constants8();
-    var { kEnumerableProperty } = util;
+    var { kEnumerableProperty, normalizedMethodRecordsBase, normalizedMethodRecords } = util;
     var { kHeaders, kSignal, kState, kDispatcher } = require_symbols7();
     var { webidl } = require_webidl2();
     var { URLSerializer } = require_data_url();
@@ -30591,17 +30582,18 @@ var require_request4 = __commonJS({
         }
         if (init.method !== void 0) {
           let method = init.method;
-          const mayBeNormalized = normalizeMethodRecord[method];
+          const mayBeNormalized = normalizedMethodRecords[method];
           if (mayBeNormalized !== void 0) {
             request2.method = mayBeNormalized;
           } else {
             if (!isValidHTTPToken(method)) {
               throw new TypeError(`'${method}' is not a valid HTTP method.`);
             }
-            if (forbiddenMethodsSet.has(method.toUpperCase())) {
+            const upperCase = method.toUpperCase();
+            if (forbiddenMethodsSet.has(upperCase)) {
               throw new TypeError(`'${method}' HTTP method is unsupported.`);
             }
-            method = normalizeMethod(method);
+            method = normalizedMethodRecordsBase[upperCase] ?? method;
             request2.method = method;
           }
           if (!patchMethodWarning && request2.method === "patch") {
@@ -35317,7 +35309,6 @@ var require_websocket2 = __commonJS({
     var { types } = require("node:util");
     var { ErrorEvent, CloseEvent } = require_events2();
     var { SendQueue } = require_sender();
-    var experimentalWarned = false;
     var WebSocket = class _WebSocket extends EventTarget {
       #events = {
         open: null,
@@ -35338,12 +35329,6 @@ var require_websocket2 = __commonJS({
         super();
         const prefix = "WebSocket constructor";
         webidl.argumentLengthCheck(arguments, 1, prefix);
-        if (!experimentalWarned) {
-          experimentalWarned = true;
-          process.emitWarning("WebSockets are experimental, expect them to change at any time.", {
-            code: "UNDICI-WS"
-          });
-        }
         const options = webidl.converters["DOMString or sequence<DOMString> or WebSocketInit"](protocols, prefix, "options");
         url = webidl.converters.USVString(url, prefix, "url");
         protocols = options.protocols;

--- a/lib/main.js
+++ b/lib/main.js
@@ -19,10 +19,12 @@ export async function main(
   core,
   createAppAuth,
   request,
-  skipTokenRevoke
+  skipTokenRevoke,
+  permissions
 ) {
   let parsedOwner = "";
   let parsedRepositoryNames = "";
+  let parsedPermissions = {};
 
   // If neither owner nor repositories are set, default to current repository
   if (!owner && !repositories) {
@@ -64,6 +66,15 @@ export async function main(
     );
   }
 
+  if (permissions) {
+    const sep = permissions.includes(",") ? "," : "\n";
+    const permissionSpecs = permissions.split(sep);
+    for (spec of permissionSpecs) {
+      const [key, value] = spec.split(":")
+      parsedPermissions[key.trim()] = value.trim();
+    }
+  }
+
   const auth = createAppAuth({
     appId,
     privateKey,
@@ -74,7 +85,7 @@ export async function main(
   // If at least one repository is set, get installation ID from that repository
 
   if (parsedRepositoryNames) {
-    ({ authentication, installationId, appSlug } = await pRetry(() => getTokenFromRepository(request, auth, parsedOwner, parsedRepositoryNames), {
+    ({ authentication, installationId, appSlug } = await pRetry(() => getTokenFromRepository(request, auth, parsedOwner, parsedRepositoryNames, parsedPermissions), {
       onFailedAttempt: (error) => {
         core.info(
           `Failed to create token for "${parsedRepositoryNames}" (attempt ${error.attemptNumber}): ${error.message}`
@@ -84,7 +95,7 @@ export async function main(
     }));
   } else {
     // Otherwise get the installation for the owner, which can either be an organization or a user account
-    ({ authentication, installationId, appSlug } = await pRetry(() => getTokenFromOwner(request, auth, parsedOwner), {
+    ({ authentication, installationId, appSlug } = await pRetry(() => getTokenFromOwner(request, auth, parsedOwner, parsedPermissions), {
       onFailedAttempt: (error) => {
         core.info(
           `Failed to create token for "${parsedOwner}" (attempt ${error.attemptNumber}): ${error.message}`
@@ -108,7 +119,7 @@ export async function main(
   }
 }
 
-async function getTokenFromOwner(request, auth, parsedOwner) {
+async function getTokenFromOwner(request, auth, parsedOwner, parsedPermissions) {
   // https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-organization-installation-for-the-authenticated-app
   const response = await request("GET /orgs/{org}/installation", {
     org: parsedOwner,
@@ -128,11 +139,17 @@ async function getTokenFromOwner(request, auth, parsedOwner) {
     });
   });
 
-  // Get token for for all repositories of the given installation
-  const authentication = await auth({
+  const authConfig = {
     type: "installation",
     installationId: response.data.id,
-  });
+  };
+
+  if (Object.keys(parsedPermissions).length > 0) {
+    authConfig["permissions"] = parsedPermissions;
+  }
+
+  // Get token for for all repositories of the given installation
+  const authentication = await auth(authConfig);
 
   const installationId = response.data.id;
   const appSlug = response.data['app_slug'];
@@ -140,7 +157,7 @@ async function getTokenFromOwner(request, auth, parsedOwner) {
   return { authentication, installationId, appSlug };
 }
 
-async function getTokenFromRepository(request, auth, parsedOwner, parsedRepositoryNames) {
+async function getTokenFromRepository(request, auth, parsedOwner, parsedRepositoryNames, parsedPermissions) {
   // https://docs.github.com/rest/apps/apps?apiVersion=2022-11-28#get-a-repository-installation-for-the-authenticated-app
   const response = await request("GET /repos/{owner}/{repo}/installation", {
     owner: parsedOwner,
@@ -150,12 +167,18 @@ async function getTokenFromRepository(request, auth, parsedOwner, parsedReposito
     },
   });
 
-  // Get token for given repositories
-  const authentication = await auth({
+  const authConfig = {
     type: "installation",
     installationId: response.data.id,
     repositoryNames: parsedRepositoryNames.split(","),
-  });
+  };
+
+  if (Object.keys(parsedPermissions).length > 0) {
+    authConfig["permissions"] = parsedPermissions;
+  }
+
+  // Get token for given repositories
+  const authentication = await auth(authConfig);
 
   const installationId = response.data.id;
   const appSlug = response.data['app_slug'];

--- a/main.js
+++ b/main.js
@@ -31,6 +31,8 @@ const skipTokenRevoke = Boolean(
   core.getInput("skip-token-revoke") || core.getInput("skip_token_revoke")
 );
 
+const permissions = core.getInput("permissions");
+
 main(
   appId,
   privateKey,
@@ -39,7 +41,8 @@ main(
   core,
   createAppAuth,
   request,
-  skipTokenRevoke
+  skipTokenRevoke,
+  permissions
 ).catch((error) => {
   /* c8 ignore next 3 */
   console.error(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-github-app-token",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-github-app-token",
-      "version": "1.10.2",
+      "version": "1.10.3",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",


### PR DESCRIPTION
This PR introduces scoped tokens that allow you to reduce the scope of a token generated by a GitHub App

This has a few benefits such as making explicit what scopes you want to use and reduce the impact if a token leaks (when its scope is reduced).

It doesn't protect against malicious code that receives the token in the same workflow, because that code can directly access the private key used to generate the code.

Perhaps an additional explicit revoking Action could be useful here where a scoped token is generated by a job associated with an environment that has access to the private key, passes that token to a job that uses it and that job revokes the token after use using that revoking Action.