### PR TITLE
refactor: remove redundant API call

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -26,9 +26,7 @@ export async function main(
 
   // If neither owner nor repositories are set, default to current repository
   if (!owner && repositories.length === 0) {
-    const [owner, repo] = String(
-      process.env.GITHUB_REPOSITORY
-    ).split("/");
+    const [owner, repo] = String(process.env.GITHUB_REPOSITORY).split("/");
     parsedOwner = owner;
     parsedRepositoryNames = [repo];
 
@@ -52,7 +50,9 @@ export async function main(
     parsedRepositoryNames = repositories;
 
     core.info(
-      `owner not set, creating owner for given repositories "${repositories.join(',')}" in current owner ("${parsedOwner}")`
+      `owner not set, creating owner for given repositories "${repositories.join(
+        ","
+      )}" in current owner ("${parsedOwner}")`
     );
   }
 
@@ -62,7 +62,9 @@ export async function main(
     parsedRepositoryNames = repositories;
 
     core.info(
-      `owner and repositories set, creating token for repositories "${repositories.join(',')}" owned by "${owner}"`
+      `owner and repositories set, creating token for repositories "${repositories.join(
+        ","
+      )}" owned by "${owner}"`
     );
   }
 
@@ -76,24 +78,38 @@ export async function main(
   // If at least one repository is set, get installation ID from that repository
 
   if (parsedRepositoryNames.length > 0) {
-    ({ authentication, installationId, appSlug } = await pRetry(() => getTokenFromRepository(request, auth, parsedOwner, parsedRepositoryNames), {
-      onFailedAttempt: (error) => {
-        core.info(
-          `Failed to create token for "${parsedRepositoryNames.join(',')}" (attempt ${error.attemptNumber}): ${error.message}`
-        );
-      },
-      retries: 3,
-    }));
+    ({ authentication, installationId, appSlug } = await pRetry(
+      () =>
+        getTokenFromRepository(
+          request,
+          auth,
+          parsedOwner,
+          parsedRepositoryNames
+        ),
+      {
+        onFailedAttempt: (error) => {
+          core.info(
+            `Failed to create token for "${parsedRepositoryNames.join(
+              ","
+            )}" (attempt ${error.attemptNumber}): ${error.message}`
+          );
+        },
+        retries: 3,
+      }
+    ));
   } else {
     // Otherwise get the installation for the owner, which can either be an organization or a user account
-    ({ authentication, installationId, appSlug } = await pRetry(() => getTokenFromOwner(request, auth, parsedOwner), {
-      onFailedAttempt: (error) => {
-        core.info(
-          `Failed to create token for "${parsedOwner}" (attempt ${error.attemptNumber}): ${error.message}`
-        );
-      },
-      retries: 3,
-    }));
+    ({ authentication, installationId, appSlug } = await pRetry(
+      () => getTokenFromOwner(request, auth, parsedOwner),
+      {
+        onFailedAttempt: (error) => {
+          core.info(
+            `Failed to create token for "${parsedOwner}" (attempt ${error.attemptNumber}): ${error.message}`
+          );
+        },
+        retries: 3,
+      }
+    ));
   }
 
   // Register the token with the runner as a secret to ensure it is masked in logs
@@ -127,12 +143,17 @@ async function getTokenFromOwner(request, auth, parsedOwner) {
   });
 
   const installationId = response.data.id;
-  const appSlug = response.data['app_slug'];
+  const appSlug = response.data["app_slug"];
 
   return { authentication, installationId, appSlug };
 }
 
-async function getTokenFromRepository(request, auth, parsedOwner, parsedRepositoryNames) {
+async function getTokenFromRepository(
+  request,
+  auth,
+  parsedOwner,
+  parsedRepositoryNames
+) {
   // https://docs.github.com/rest/apps/apps?apiVersion=2022-11-28#get-a-repository-installation-for-the-authenticated-app
   const response = await request("GET /repos/{owner}/{repo}/installation", {
     owner: parsedOwner,
@@ -150,7 +171,7 @@ async function getTokenFromRepository(request, auth, parsedOwner, parsedReposito
   });
 
   const installationId = response.data.id;
-  const appSlug = response.data['app_slug'];
+  const appSlug = response.data["app_slug"];
 
   return { authentication, installationId, appSlug };
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -111,23 +111,13 @@ export async function main(
 }
 
 async function getTokenFromOwner(request, auth, parsedOwner) {
-  // https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-organization-installation-for-the-authenticated-app
-  const response = await request("GET /orgs/{org}/installation", {
-    org: parsedOwner,
+  // https://docs.github.com/rest/apps/apps?apiVersion=2022-11-28#get-a-user-installation-for-the-authenticated-app
+  // This endpoint works for both users and organizations
+  const response = await request("GET /users/{username}/installation", {
+    username: parsedOwner,
     request: {
       hook: auth.hook,
     },
-  }).catch((error) => {
-    /* c8 ignore next */
-    if (error.status !== 404) throw error;
-
-    // https://docs.github.com/rest/apps/apps?apiVersion=2022-11-28#get-a-user-installation-for-the-authenticated-app
-    return request("GET /users/{username}/installation", {
-      username: parsedOwner,
-      request: {
-        hook: auth.hook,
-      },
-    });
   });
 
   // Get token for for all repositories of the given installation

--- a/tests/main-token-get-owner-set-to-org-repo-unset.test.js
+++ b/tests/main-token-get-owner-set-to-org-repo-unset.test.js
@@ -10,7 +10,7 @@ await test((mockPool) => {
   const mockAppSlug = "github-actions";
   mockPool
     .intercept({
-      path: `/orgs/${process.env.INPUT_OWNER}/installation`,
+      path: `/users/${process.env.INPUT_OWNER}/installation`,
       method: "GET",
       headers: {
         accept: "application/vnd.github.v3+json",

--- a/tests/main-token-get-owner-set-to-user-fail-response.test.js
+++ b/tests/main-token-get-owner-set-to-user-fail-response.test.js
@@ -1,6 +1,6 @@
 import { test } from "./main.js";
 
-// Verify `main` successfully obtains a token when the `owner` input is set (to a user), but the `repositories` input isn’t set.
+// Verify retries work when getting a token for a user or organization fails on the first attempt.
 await test((mockPool) => {
   process.env.INPUT_OWNER = "smockle";
   delete process.env.INPUT_REPOSITORIES;
@@ -10,7 +10,7 @@ await test((mockPool) => {
   const mockAppSlug = "github-actions";
   mockPool
     .intercept({
-      path: `/orgs/${process.env.INPUT_OWNER}/installation`,
+      path: `/users/${process.env.INPUT_OWNER}/installation`,
       method: "GET",
       headers: {
         accept: "application/vnd.github.v3+json",
@@ -21,7 +21,7 @@ await test((mockPool) => {
     .reply(500, "GitHub API not available");
   mockPool
     .intercept({
-      path: `/orgs/${process.env.INPUT_OWNER}/installation`,
+      path: `/users/${process.env.INPUT_OWNER}/installation`,
       method: "GET",
       headers: {
         accept: "application/vnd.github.v3+json",

--- a/tests/main-token-get-owner-set-to-user-repo-unset.test.js
+++ b/tests/main-token-get-owner-set-to-user-repo-unset.test.js
@@ -10,17 +10,6 @@ await test((mockPool) => {
   const mockAppSlug = "github-actions";
   mockPool
     .intercept({
-      path: `/orgs/${process.env.INPUT_OWNER}/installation`,
-      method: "GET",
-      headers: {
-        accept: "application/vnd.github.v3+json",
-        "user-agent": "actions/create-github-app-token",
-        // Intentionally omitting the `authorization` header, since JWT creation is not idempotent.
-      },
-    })
-    .reply(404);
-  mockPool
-    .intercept({
       path: `/users/${process.env.INPUT_OWNER}/installation`,
       method: "GET",
       headers: {


### PR DESCRIPTION
Combines the two installation requests (org and user) into one because `/org/{org}` can also be accessed at `/users/{org}`.