### PR TITLE
ci(dependabot): only group minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,30 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: 'production'
+        update-types:
+          - minor
+          - patch
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: 'development'
+        update-types:
+          - minor
+          - patch
     commit-message:
-      prefix: "fix"
-      prefix-development: "build"
-      include: "scope"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      prefix: 'fix'
+      prefix-development: 'build'
+      include: 'scope'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
This pull request updates the Dependabot configuration to only group minor and patch updates.