### PR TITLE
docs(README): remove extra space in variable syntax in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - id: committer
         run: echo "string=${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>"  >> "$GITHUB_OUTPUT"
-      - run: echo "committer string is ${ {steps.committer.outputs.string }}"
+      - run: echo "committer string is ${{ steps.committer.outputs.string }}"
 ```
 
 ### Configure git CLI for an app's bot user


### PR DESCRIPTION
### Fix syntax error in GitHub Actions example in README  

This PR fixes a syntax error in the "Create a git committer string for an app installation" example in the README file.  

#### What was wrong?  
The example contained an incorrect space in the variable syntax:  
```yaml  
${ {steps.committer.outputs.string }}  
```  
This caused the example to fail, as GitHub Actions does not allow spaces in variable interpolation.  

#### What was fixed?  
The syntax was corrected to:  
```yaml  
${{ steps.committer.outputs.string }}  
```  

This fix ensures that users can copy and use the example without encountering any errors.  
