### PR TITLE
Remove individuals form CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gr2m @parkerbxyz @actions/create-github-app-token-maintainers
+* @actions/create-github-app-token-maintainers


### PR DESCRIPTION
Since we have the `@actions/create-github-app-token-maintainers`, we don't need explicit references to individuals on that team.