### PR TITLE
build: update package-lock.json on release

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         {
           "assets": [
             "package.json",
+            "package-lock.json",
             "dist/*"
           ],
           "message": "build(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"


### PR DESCRIPTION
This pull request updates the release configuration to include package-lock.json. This should ensure the action version is update in package-lock.json when the release workflow runs.