### PR TITLE
ci(update-permission-inputs): add permissions

### DIFF
--- a/.github/workflows/update-permission-inputs.yml
+++ b/.github/workflows/update-permission-inputs.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   update-permission-inputs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `contents: write` permissions to the update-permission-inputs.yml workflow file.