### PR TITLE
Add action typing

### DIFF
--- a/.github/workflows/check-action-typing.yml
+++ b/.github/workflows/check-action-typing.yml
@@ -1,0 +1,16 @@
+name: Check Action Typing
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  check_action_typing:
+    name: Check Action Typing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check Action Typing
+        uses: typesafegithub/github-actions-typing@v2

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 GitHub Action for creating a GitHub App installation access token.
 
+Thanks to the provided [typings](action-types.yml), it is possible to use this action in a type-safe way using
+https://github.com/typesafegithub/github-workflows-kt which allows writing workflow files using a type-safe Kotlin DSL.
+
 ## Usage
 
 In order to use this action, you need to:

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,0 +1,321 @@
+# See https://github.com/typesafegithub/github-actions-typing
+inputs:
+  app-id:
+    type: string
+
+  private-key:
+    type: string
+
+  owner:
+    type: string
+
+  repositories:
+    type: list
+    separator: "\n"
+    list-item:
+      type: string
+
+  skip-token-revoke:
+    type: boolean
+
+  github-api-url:
+    type: string
+
+  # <START GENERATED PERMISSIONS TYPES>
+  permission-actions:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-administration:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-checks:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-codespaces:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-contents:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-dependabot-secrets:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-deployments:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-email-addresses:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-environments:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-followers:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-git-ssh-keys:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-gpg-keys:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-interaction-limits:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-issues:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-members:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-metadata:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-organization-administration:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-organization-announcement-banners:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-organization-copilot-seat-management:
+    type: enum
+    allowed-values:
+      - "write"
+
+  permission-organization-custom-org-roles:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-organization-custom-properties:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+      - "admin"
+
+  permission-organization-custom-roles:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-organization-events:
+    type: enum
+    allowed-values:
+      - "read"
+
+  permission-organization-hooks:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-organization-packages:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-organization-personal-access-token-requests:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-organization-personal-access-tokens:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-organization-plan:
+    type: enum
+    allowed-values:
+      - "read"
+
+  permission-organization-projects:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+      - "admin"
+
+  permission-organization-secrets:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-organization-self-hosted-runners:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-organization-user-blocking:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-packages:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-pages:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-profile:
+    type: enum
+    allowed-values:
+      - "write"
+
+  permission-pull-requests:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-repository-custom-properties:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-repository-hooks:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-repository-projects:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+      - "admin"
+
+  permission-secret-scanning-alerts:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-secrets:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-security-events:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-single-file:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-starring:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-statuses:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-team-discussions:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-vulnerability-alerts:
+    type: enum
+    allowed-values:
+      - "read"
+      - "write"
+
+  permission-workflows:
+    type: enum
+    allowed-values:
+      - "write"
+
+  # <END GENERATED PERMISSIONS TYPES>
+
+outputs:
+  token:
+    type: string
+
+  installation-id:
+    type: integer
+
+  app-slug:
+    type: string

--- a/scripts/update-permission-inputs.js
+++ b/scripts/update-permission-inputs.js
@@ -30,13 +30,36 @@ const permissionsInputs = Object.entries(appPermissionsSchema.properties)
     description: "${description}"`;
   }, "");
 
-const actionsYamlContent = await readFile("action.yml", "utf8");
+const actionYamlContent = await readFile("action.yml", "utf8");
 
 // In the action.yml file, replace the content between the `<START GENERATED PERMISSIONS INPUTS>` and `<END GENERATED PERMISSIONS INPUTS>` comments with the new content
-const updatedActionsYamlContent = actionsYamlContent.replace(
+const updatedActionYamlContent = actionYamlContent.replace(
   /(?<=# <START GENERATED PERMISSIONS INPUTS>)(.|\n)*(?=# <END GENERATED PERMISSIONS INPUTS>)/,
   permissionsInputs + "\n  "
 );
 
-await writeFile("action.yml", updatedActionsYamlContent, "utf8");
+await writeFile("action.yml", updatedActionYamlContent, "utf8");
 console.log("Updated action.yml with new permissions inputs");
+
+const permissionsTypes = Object.entries(appPermissionsSchema.properties)
+  .sort((a, b) => a[0].localeCompare(b[0]))
+  .reduce((result, [key, value]) => {
+    const permissionAccessValues = value.enum.map((p) => `      - "${p}"`).reduce((result, p) => `${result}\n${p}`);
+    return `${result}
+  permission-${key.replace(/_/g, "-")}:
+    type: enum
+    allowed-values:
+${permissionAccessValues}
+`;
+  }, "");
+
+const actionTypesYamlContent = await readFile("action-types.yml", "utf8");
+
+// In the action-types.yml file, replace the content between the `<START GENERATED PERMISSIONS TYPES>` and `<END GENERATED PERMISSIONS TYPES>` comments with the new content
+const updatedActionTypesYamlContent = actionTypesYamlContent.replace(
+  /(?<=# <START GENERATED PERMISSIONS TYPES>)(.|\n)*(?=# <END GENERATED PERMISSIONS TYPES>)/,
+  permissionsTypes + "\n  "
+);
+
+await writeFile("action-types.yml", updatedActionTypesYamlContent, "utf8");
+console.log("Updated action-types.yml with new permissions types");


### PR DESCRIPTION
I would like to see your action first-class supported by https://github.com/typesafegithub/github-workflows-kt, a Kotlin DSL to write GitHub Action workflows.

The project came up with ways to reduce operational load when keeping the library's action wrappers in sync with actions' inputs and outputs.
The solutions include onboarding https://github.com/typesafegithub/github-actions-typing.
It is as easy as adding an extra YAML file to your repository root, and (optionally) adding a simple GitHub workflow that validates this new file.
Thanks to this, the code generator in the Kotlin DSL can fetch typing info provided by you instead of them, which has a number of benefits.
It has no negative effects on current action consumers, they continue to use the action via regular GitHub API, as if the file was not there.

In this pull request, I would like to ask you if you are open to introduce such typings in your action and also provide the current state as far as I could determine it.
You would not be the first, there are already other actions using it, like e.g. my https://github.com/Vampire/setup-wsl or also Microsoft's https://github.com/microsoft/setup-msbuild.

Also "regular" users can benefit from this clear and formalized typing definition, seeing exactly what values are valid.
And as the typings are made independent from the Kotlin DSL library, also other DSL or similar consumers could use these typings in the future.

When accepting this PR and in the future maintaining the typing yourself,
please keep in mind that API are generated from these typing information.
So if you for example recognize that a type is wrong and want to change it for example from `string` to `integer`,
this would be a breaking change for such consumers and should therefore be done with a major version bump.
Backwards compatible changes like new enum options, or new inputs or outputs can of course be released in a minor version as usual.

After hopefully merging this PR it would be nice if you could cut a release soon,
so that the shiny new typings can be used right away.


