### PR TITLE
Add beta branch support for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,9 @@ name: release
 on:
   push:
     branches:
+      - "*.x"
       - main
+      - beta
 
 permissions:
   contents: write

--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
   "release": {
     "branches": [
       "+([0-9]).x",
-      "main"
+      "main",
+      {
+        "name": "beta",
+        "prerelease": true
+      }
     ],
     "plugins": [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
Updated release workflow and semantic-release config to include the beta branch and pattern-matched branches for release automation. The beta branch is now marked as a prerelease.