### PR TITLE
docs: update procedure to configure Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ jobs:
           # required
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
       - name: Get GitHub App User ID
         id: get-user-id
         run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
@@ -112,7 +113,10 @@ jobs:
       - run: |
           git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-      # git commands like commit work using the bot user
+          gh auth setup-git
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      # git commands like commit and push work using the bot user
       - run: |
           git add .
           git commit -m "Auto-generated changes"


### PR DESCRIPTION
The current procedure for configuring `git` does not allow it to push commits
besides the current repository, even if the app token may have access to other
repositories. It also does not allow `git` to clone such a repository.

This new procedure configures `gh` first and then calls `gh auth setup-git`
to configure `git` so it will work for any repository that the token has access to.