### PR TITLE
Update `actions/checkout` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.head_ref }}
-          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
-          persist-credentials: false
-      - uses: creyD/prettier_action@v4.3
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
+      - name: Make File Changes
+        run: ~
+      - name: Push with App Token 
+        run: |
+          git add .
+          git commit -m "Auto-generated changes"
+          git push
 ```
 
 ### Create a git committer string for an app installation


### PR DESCRIPTION
Updates the `actions/checkout` doc section to demonstrate how to push a commit using the generated token. 

My experience was that I came here because I needed to push with a app token so my CI would run after. 

So an example of how to do that would have been more helpful then a example on how to prevent using this token to push. 

Closing my other PR as I think this better addresses what I came to the docs looking for.