### PR TITLE
ci(test): trigger on merge_group

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     name: end-to-end
     runs-on: ubuntu-latest
     # do not run from forks, as forks don’t have access to repository secrets
-    if: github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
+    if: github.event_name == 'merge_group' || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
This pull request makes minor updates to the GitHub Actions workflow configuration in `.github/workflows/test.yml`, focusing on standardizing job naming and adding support for merge group events.