### PR TITLE
ci: create stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 # This workflow warns and then closes issues that have had no activity for a specified amount of time.
 # https://github.com/actions/stale
 
-name: Manage stale issues
+name: Stale
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Introduces a GitHub Actions workflow that automatically marks issues and pull requests as stale after 180 days of inactivity and closes them after an additional 60 days. This helps keep the repository clean and maintainable by prompting action on inactive items.