### PR TITLE
chore: add extraPermissions to generate action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,8 @@ inputs:
     description: "The level of permission to grant the access token for GitHub Actions workflows, workflow runs, and artifacts. Can be set to 'read' or 'write'."
   permission-administration:
     description: "The level of permission to grant the access token for repository creation, deletion, settings, teams, and collaborators creation. Can be set to 'read' or 'write'."
+  permission-attestations:
+    description: "The level of permission to grant the access token to create and manage GitHub attestations. Can be set to 'read' or 'write'."
   permission-checks:
     description: "The level of permission to grant the access token for checks on code. Can be set to 'read' or 'write'."
   permission-codespaces:
@@ -95,6 +97,8 @@ inputs:
     description: "The level of permission to grant the access token to view and manage GitHub Actions self-hosted runners available to an organization. Can be set to 'read' or 'write'."
   permission-organization-user-blocking:
     description: "The level of permission to grant the access token to view and manage users blocked by the organization. Can be set to 'read' or 'write'."
+  permission-organization-variables:
+    description: "The level of permission to grant the access token to manage organization variables. Can be set to 'read' or 'write'."
   permission-packages:
     description: "The level of permission to grant the access token for packages published to GitHub Packages. Can be set to 'read' or 'write'."
   permission-pages:
@@ -123,6 +127,8 @@ inputs:
     description: "The level of permission to grant the access token for commit statuses. Can be set to 'read' or 'write'."
   permission-team-discussions:
     description: "The level of permission to grant the access token to manage team discussions and related comments. Can be set to 'read' or 'write'."
+  permission-variables:
+    description: "The level of permission to grant the access token to manage GitHub Actions configuration variables. Can be set to 'read' or 'write'."
   permission-vulnerability-alerts:
     description: "The level of permission to grant the access token to manage Dependabot alerts. Can be set to 'read' or 'write'."
   permission-workflows:

--- a/scripts/update-permission-inputs.js
+++ b/scripts/update-permission-inputs.js
@@ -13,7 +13,31 @@ await writeFile(
   "utf8"
 );
 
-const permissionsInputs = Object.entries(appPermissionsSchema.properties)
+const extraPermissions = {
+  attestations: {
+    type: "string",
+    description:
+      "The level of permission to grant the access token to create and manage GitHub attestations.",
+    enum: ["read", "write"],
+  },
+  "organization-variables": {
+    type: "string",
+    description:
+      "The level of permission to grant the access token to manage organization variables.",
+    enum: ["read", "write"],
+  },
+  variables: {
+    type: "string",
+    description:
+      "The level of permission to grant the access token to manage GitHub Actions configuration variables.",
+    enum: ["read", "write"],
+  },
+};
+
+const permissionsInputs = Object.entries({
+  ...appPermissionsSchema.properties,
+  ...extraPermissions,
+})
   .sort((a, b) => a[0].localeCompare(b[0]))
   .reduce((result, [key, value]) => {
     const formatter = new Intl.ListFormat("en", {


### PR DESCRIPTION
add extraPermissions to add `permissions-variables` and `permissions-attestations` as generator based on openapi spec is broken

Fixes:

https://github.com/actions/create-github-app-token/issues/310
https://github.com/actions/create-github-app-token/issues/231