### PR TITLE
chore: update to Node v24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -136,6 +136,6 @@ outputs:
   app-slug:
     description: "GitHub App slug"
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/main.cjs"
   post: "dist/post.cjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "yaml": "^2.8.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "version": "2.2.1",
   "description": "GitHub Action for creating a GitHub App Installation Access Token",
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
-  "packageManager": "npm@10.9.4",
+  "packageManager": "npm@11.9.0",
   "scripts": {
     "build": "esbuild main.js post.js --bundle --outdir=dist --out-extension:.js=.cjs --platform=node --target=node20.0.0 --packages=bundle",
     "test": "c8 --100 ava tests/index.js",


### PR DESCRIPTION
This updates the action to build, test, and execute in Node 24. As mentioned in #328, Node 20 has been deprecated for running actions; so this change is necessary.

Resolves #328