### PR TITLE
Add missing `permission-discussions` input to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,8 @@ inputs:
     description: "The level of permission to grant the access token to manage Dependabot secrets. Can be set to 'read' or 'write'."
   permission-deployments:
     description: "The level of permission to grant the access token for deployments and deployment statuses. Can be set to 'read' or 'write'."
+  permission-discussions:
+    description: "The level of permission to grant the access token for discussions. Can be set to 'read' or 'write'."
   permission-email-addresses:
     description: "The level of permission to grant the access token to manage the email addresses belonging to a user. Can be set to 'read' or 'write'."
   permission-enterprise-custom-properties-for-organizations:


### PR DESCRIPTION
## Problem

The `discussions` permission is already handled at runtime via `process.env` (like all other permissions), but it was never declared as an input in `action.yml`. This causes an **"Unexpected input 'permission-discussions'"** warning when users set it in their workflows.

## Fix

Add the `permission-discussions` input declaration to `action.yml`, matching the pattern of all other permission inputs. This is a 2-line change — no runtime behavior changes.

## Related

- Fixes #359
- Related: github/gh-aw#25709 (compiler-side fix for the same permission)