### PR TITLE
fix: improve error message when app identifier is empty

### DIFF
--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -23352,7 +23352,7 @@ async function run() {
   ensureNativeProxySupport();
   const clientId = getInput("client-id") || getInput("app-id");
   if (!clientId) {
-    throw new Error("Either 'client-id' or 'app-id' input must be set");
+    throw new Error("The 'client-id' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.");
   }
   const privateKey = getInput("private-key");
   const owner = getInput("owner");

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -23352,7 +23352,7 @@ async function run() {
   ensureNativeProxySupport();
   const clientId = getInput("client-id") || getInput("app-id");
   if (!clientId) {
-    throw new Error("The 'client-id' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.");
+    throw new Error("The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.");
   }
   const privateKey = getInput("private-key");
   const owner = getInput("owner");

--- a/main.js
+++ b/main.js
@@ -20,7 +20,7 @@ async function run() {
 
   const clientId = core.getInput("client-id") || core.getInput("app-id");
   if (!clientId) {
-    throw new Error("The 'client-id' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.");
+    throw new Error("The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.");
   }
   const privateKey = core.getInput("private-key");
   const owner = core.getInput("owner");

--- a/main.js
+++ b/main.js
@@ -20,7 +20,7 @@ async function run() {
 
   const clientId = core.getInput("client-id") || core.getInput("app-id");
   if (!clientId) {
-    throw new Error("Either 'client-id' or 'app-id' input must be set");
+    throw new Error("The 'client-id' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.");
   }
   const privateKey = core.getInput("private-key");
   const owner = core.getInput("owner");

--- a/tests/index.js.snapshot
+++ b/tests/index.js.snapshot
@@ -56,11 +56,11 @@ POST /api/v3/app/installations/123456/access_tokens
 `;
 
 exports[`main-missing-client-and-app-id.test.js > stderr 1`] = `
-The 'client-id' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.
+The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.
 `;
 
 exports[`main-missing-client-and-app-id.test.js > stdout 1`] = `
-::error::The 'client-id' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.
+::error::The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.
 `;
 
 exports[`main-missing-owner.test.js > stderr 1`] = `

--- a/tests/index.js.snapshot
+++ b/tests/index.js.snapshot
@@ -56,11 +56,11 @@ POST /api/v3/app/installations/123456/access_tokens
 `;
 
 exports[`main-missing-client-and-app-id.test.js > stderr 1`] = `
-Either 'client-id' or 'app-id' input must be set
+The 'client-id' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.
 `;
 
 exports[`main-missing-client-and-app-id.test.js > stdout 1`] = `
-::error::Either 'client-id' or 'app-id' input must be set
+::error::The 'client-id' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.
 `;
 
 exports[`main-missing-owner.test.js > stderr 1`] = `


### PR DESCRIPTION
When `client-id` (or the deprecated `app-id`) resolves to an empty string, for example because a secret or variable is not available in the workflow context, the error message from `@octokit/auth-app` is not very helpful:

```
[@octokit/auth-app] appId option is required
```

A validation check was added recently to catch this earlier, but its message could be more informative:

```
Either 'client-id' or 'app-id' input must be set
```

This updates the message to clarify that the value resolved to empty and nudges users toward checking their secret or variable availability:

```
The 'client-id' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.
```

Closes #249