### PR TITLE
ci: use existing release tag format

### DIFF
--- a/release-please-config.beta.json
+++ b/release-please-config.beta.json
@@ -4,6 +4,7 @@
     ".": {
       "prerelease": true,
       "prerelease-type": "beta",
+      "include-component-in-tag": false,
       "release-type": "node",
       "versioning": "prerelease"
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
+      "include-component-in-tag": false,
       "release-type": "node"
     }
   }


### PR DESCRIPTION
## Summary

This updates the release-please manifest configuration to use the repository's existing `vX.Y.Z` tag format. Without this setting, manifest mode looks for component-prefixed tags like `create-github-app-token-v3.1.1`, which do not exist in this repository and can cause release-please to include already-released commits in a new release PR.

## Changes

- Sets `include-component-in-tag` to `false` for stable releases.
- Sets `include-component-in-tag` to `false` for beta prereleases.

This should make release-please use tags like `v3.1.1` as the previous release boundary.