### PR TITLE
fix: validate private-key input

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,6 +23,9 @@ async function run() {
     throw new Error("The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.");
   }
   const privateKey = core.getInput("private-key");
+  if (!privateKey) {
+    throw new Error("The 'private-key' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.");
+  }
   const enterprise = core.getInput("enterprise");
   const owner = core.getInput("owner");
   const repositories = core

--- a/tests/index.js.snapshot
+++ b/tests/index.js.snapshot
@@ -165,6 +165,14 @@ exports[`main-missing-owner.test.js > stderr 1`] = `
 GITHUB_REPOSITORY_OWNER missing, must be set to '<owner>'
 `;
 
+exports[`main-missing-private-key.test.js > stderr 1`] = `
+The 'private-key' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.
+`;
+
+exports[`main-missing-private-key.test.js > stdout 1`] = `
+::error::The 'private-key' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.
+`;
+
 exports[`main-missing-repository.test.js > stderr 1`] = `
 GITHUB_REPOSITORY missing, must be set to '<owner>/<repo>'
 `;

--- a/tests/main-missing-private-key.test.js
+++ b/tests/main-missing-private-key.test.js
@@ -1,0 +1,19 @@
+import { DEFAULT_ENV } from "./main.js";
+
+for (const [key, value] of Object.entries({
+  ...DEFAULT_ENV,
+  "INPUT_PRIVATE-KEY": "",
+})) {
+  process.env[key] = value;
+}
+
+// Log only the error message, not the full stack trace, because the stack
+// trace contains environment-specific paths and ANSI codes that differ
+// between local and CI environments.
+const _error = console.error;
+console.error = (err) => _error(err?.message ?? err);
+
+// Verify `main` exits with an error when `private-key` is not set.
+const { default: promise } = await import("../main.js");
+await promise;
+process.exitCode = 0;


### PR DESCRIPTION
## Summary

When `private-key` resolves to an empty value, the action currently lets Octokit fail with `[@octokit/auth-app] privateKey option is required`, which points at an implementation detail instead of the action input. This adds action-level validation so users get the same non-empty input guidance used for missing `client-id` or `app-id`.

- Validate `private-key` before creating app auth
- Add a regression test and snapshot for the missing private key path
- Leave valid private key handling unchanged, including escaped newlines