### PR TITLE
feat: support aggregate permissions input

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,11 +397,17 @@ steps:
 > [!NOTE]
 > The `enterprise` input is mutually exclusive with `owner` and `repositories`. Use it when the GitHub App is installed on an enterprise account. Enterprise installation tokens can call enterprise APIs, but do not grant organization or repository access.
 
+### `permissions`
+
+**Optional:** Comma-separated permissions to grant to the token, using `permission-name: access-level` pairs. For example, `contents: read,pull-requests: write`.
+
+This input is useful when wrapping the action in a composite action that needs to forward a configurable set of permissions. Individual `permission-<permission name>` inputs override duplicate permissions in this list.
+
 ### `permission-<permission name>`
 
 **Optional:** The permissions to grant to the token. By default, the token inherits all of the installation's permissions. We recommend to explicitly list the permissions that are required for a use case. This follows GitHub's own recommendation to [control permissions of `GITHUB_TOKEN` in workflows](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token). The documentation also lists all available permissions, just prefix the permission key with `permission-` (e.g., `pull-requests` → `permission-pull-requests`).
 
-The reason we define one `permision-<permission name>` input per permission is to benefit from type intelligence and input validation built into GitHub's action runner.
+The individual `permission-<permission name>` inputs make supported permissions discoverable and allow GitHub's action runner to warn about unknown inputs.
 
 ### `skip-token-revoke`
 

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
   github-api-url:
     description: The URL of the GitHub REST API.
     default: ${{ github.api_url }}
+  permissions:
+    description: "Comma-separated permissions to grant the token, in 'permission-name: access-level' format. Individual permission-* inputs override duplicate permissions."
+    required: false
   # <START GENERATED PERMISSIONS INPUTS>
   permission-actions:
     description: "The level of permission to grant the access token for GitHub Actions workflows, workflow runs, and artifacts. Can be set to 'read' or 'write'."

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -22943,19 +22943,33 @@ function createAppAuth(options) {
 
 // lib/get-permissions-from-inputs.js
 function getPermissionsFromInputs(env) {
-  return Object.entries(env).reduce((permissions, [key, value]) => {
-    if (!key.startsWith("INPUT_PERMISSION-")) return permissions;
-    if (!value) return permissions;
+  const permissions = parsePermissionsInput(env.INPUT_PERMISSIONS);
+  return Object.entries(env).reduce((permissions2, [key, value]) => {
+    if (!key.startsWith("INPUT_PERMISSION-")) return permissions2;
+    if (!value) return permissions2;
     const permission = key.slice("INPUT_PERMISSION-".length).toLowerCase().replaceAll(/-/g, "_");
-    if (permissions === void 0) {
-      return { [permission]: value };
-    }
     return {
-      // @ts-expect-error - needs to be typed correctly
-      ...permissions,
+      ...permissions2,
       [permission]: value
     };
-  }, void 0);
+  }, permissions);
+}
+function parsePermissionsInput(input) {
+  if (!input) return void 0;
+  return input.split(",").reduce((permissions, pair) => {
+    const separatorIndex = pair.indexOf(":");
+    const name = pair.slice(0, separatorIndex).trim();
+    const level = pair.slice(separatorIndex + 1).trim();
+    if (separatorIndex === -1 || !name || !level) {
+      throw new Error(
+        `Invalid permission '${pair.trim()}'. Expected 'permission-name: access-level'.`
+      );
+    }
+    return {
+      ...permissions,
+      [name.replaceAll("-", "_")]: level
+    };
+  }, {});
 }
 
 // node_modules/is-network-error/index.js

--- a/lib/get-permissions-from-inputs.js
+++ b/lib/get-permissions-from-inputs.js
@@ -1,11 +1,13 @@
 /**
- * Finds all permissions passed via `permision-*` inputs and turns them into an object.
+ * Finds permissions passed via `permissions` and `permission-*` inputs and turns them into an object.
  *
  * @see https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#inputs
  * @param {NodeJS.ProcessEnv} env
  * @returns {undefined | Record<string, string>}
  */
 export function getPermissionsFromInputs(env) {
+  const permissions = parsePermissionsInput(env.INPUT_PERMISSIONS);
+
   return Object.entries(env).reduce((permissions, [key, value]) => {
     if (!key.startsWith("INPUT_PERMISSION-")) return permissions;
     if (!value) return permissions;
@@ -13,15 +15,34 @@ export function getPermissionsFromInputs(env) {
     const permission = key.slice("INPUT_PERMISSION-".length).toLowerCase()
       .replaceAll(/-/g, "_");
 
-    // Inherit app permissions if no permissions inputs are set
-    if (permissions === undefined) {
-      return { [permission]: value };
-    }
-
     return {
-      // @ts-expect-error - needs to be typed correctly
       ...permissions,
       [permission]: value,
     };
-  }, undefined);
+  }, permissions);
+}
+
+/**
+ * @param {string | undefined} input
+ * @returns {undefined | Record<string, string>}
+ */
+function parsePermissionsInput(input) {
+  if (!input) return undefined;
+
+  return input.split(",").reduce((permissions, pair) => {
+    const separatorIndex = pair.indexOf(":");
+    const name = pair.slice(0, separatorIndex).trim();
+    const level = pair.slice(separatorIndex + 1).trim();
+
+    if (separatorIndex === -1 || !name || !level) {
+      throw new Error(
+        `Invalid permission '${pair.trim()}'. Expected 'permission-name: access-level'.`
+      );
+    }
+
+    return {
+      ...permissions,
+      [name.replaceAll("-", "_")]: level,
+    };
+  }, {});
 }

--- a/tests/get-permissions-from-inputs.test.js
+++ b/tests/get-permissions-from-inputs.test.js
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+
+import { getPermissionsFromInputs } from "../lib/get-permissions-from-inputs.js";
+
+assert.equal(getPermissionsFromInputs({}), undefined);
+
+assert.deepEqual(
+  getPermissionsFromInputs({
+    INPUT_PERMISSIONS: "contents: read,pull-requests: write",
+    "INPUT_PERMISSION-CONTENTS": "write",
+  }),
+  {
+    contents: "write",
+    pull_requests: "write",
+  }
+);
+
+for (const input of ["contents", ": read", "contents: "]) {
+  assert.throws(
+    () => getPermissionsFromInputs({ INPUT_PERMISSIONS: input }),
+    /Expected 'permission-name: access-level'/
+  );
+}

--- a/tests/index.js.snapshot
+++ b/tests/index.js.snapshot
@@ -540,6 +540,23 @@ POST /app/installations/123456/access_tokens
 {"repositories":["create-github-app-token"]}
 `;
 
+exports[`main-token-permissions-list-set.test.js > stdout 1`] = `
+Inputs 'owner' and 'repositories' are not set. Creating token for this repository (actions/create-github-app-token).
+::add-mask::ghs_16C7e42F292c6912E7710c838347Ae178B4a
+
+::set-output name=token::ghs_16C7e42F292c6912E7710c838347Ae178B4a
+
+::set-output name=installation-id::123456
+
+::set-output name=app-slug::github-actions
+::save-state name=token::ghs_16C7e42F292c6912E7710c838347Ae178B4a
+::save-state name=expiresAt::2016-07-11T22:14:10Z
+--- REQUESTS ---
+GET /repos/actions/create-github-app-token/installation
+POST /app/installations/123456/access_tokens
+{"repositories":["create-github-app-token"],"permissions":{"contents":"read","pull_requests":"write"}}
+`;
+
 exports[`main-token-permissions-set.test.js > stdout 1`] = `
 Inputs 'owner' and 'repositories' are not set. Creating token for this repository (actions/create-github-app-token).
 ::add-mask::ghs_16C7e42F292c6912E7710c838347Ae178B4a

--- a/tests/main-token-permissions-list-set.test.js
+++ b/tests/main-token-permissions-list-set.test.js
@@ -1,0 +1,6 @@
+import { DEFAULT_ENV, test } from "./main.js";
+
+await test(() => {}, {
+  ...DEFAULT_ENV,
+  "INPUT_PERMISSIONS": "contents: read,pull-requests: write",
+});


### PR DESCRIPTION
Addresses https://github.com/actions/create-github-app-token/issues/322, looks something like this in practice:

```
  - name: Create test GitHub App token
    id: test-app-token
    uses: trent-abc/create-github-app-token@d72c643ae8e84e205c46cb5c773a634e337e74bc # v3.2.0-aggregate-permissions
    with:
      owner: ${{ github.repository_owner }}
      repositories: ${{ inputs.repositories }}
      permissions: "contents: read,pull-requests: read"
```

Vibed up from Sol so can't guarantee the unit tests, but functionally worked in my testing. Please feel free to edit.