### PR TITLE
feat: add `jwt` input for a caller-signed token

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ If you set `HTTP_PROXY` or `HTTPS_PROXY`, also set `NODE_USE_ENV_PROXY: "1"` on 
 
 ### `private-key`
 
-**Required:** GitHub App private key. Escaped newlines (`\\n`) will be automatically replaced with actual newlines.
+**Required, unless `jwt` is set:** GitHub App private key. Escaped newlines (`\\n`) will be automatically replaced with actual newlines.
 
 Some other actions may require the private key to be Base64 encoded. To avoid recreating a new secret, it can be decoded on the fly, but it needs to be managed securely. Here is an example of how this can be achieved:
 
@@ -376,6 +376,31 @@ steps:
       client-id: ${{ vars.APP_CLIENT_ID }}
       private-key: ${{ steps.decode.outputs.private-key }}
 ```
+
+### `jwt`
+
+**Required, unless `private-key` is set:** A GitHub App JSON Web Token (JWT), signed outside of this action. Use it when the private key must never enter the workflow, for example when it is held in a hardware security module or a secret store that exposes a signing endpoint instead of the key itself.
+
+The action does not verify the token, it passes it to GitHub as-is, and reads the `exp` claim to know when it expires. The token must be signed as [GitHub documents](https://docs.github.com/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app), and `client-id` must still be set so the action can identify the app.
+
+```yaml
+steps:
+  - name: Sign a JWT with the key held in the secret store
+    id: sign
+    run: |
+      jwt=$(sign-jwt --key-id "$KEY_ID" --issuer "${{ vars.APP_CLIENT_ID }}")
+      echo "::add-mask::$jwt"
+      echo "jwt=$jwt" >> "$GITHUB_OUTPUT"
+  - name: Generate GitHub App Token
+    id: app-token
+    uses: actions/create-github-app-token@v3
+    with:
+      client-id: ${{ vars.APP_CLIENT_ID }}
+      jwt: ${{ steps.sign.outputs.jwt }}
+```
+
+> [!NOTE]
+> `jwt` is mutually exclusive with `private-key`. A JWT is valid for at most 10 minutes and this action cannot renew one, so sign it in the step right before this one.
 
 ### `owner`
 

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,11 @@ inputs:
     required: false
     deprecationMessage: "Use 'client-id' instead."
   private-key:
-    description: "GitHub App private key"
-    required: true
+    description: "GitHub App private key (mutually exclusive with 'jwt')"
+    required: false
+  jwt:
+    description: "A GitHub App JSON Web Token (JWT) signed elsewhere, for when the private key must not enter the workflow (mutually exclusive with 'private-key')"
+    required: false
   owner:
     description: "The owner of the GitHub App installation (defaults to current repository owner)"
     required: false

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,6 +5,7 @@ import isNetworkError from "is-network-error";
 /**
  * @param {string} clientId
  * @param {string} privateKey
+ * @param {string} jwt
  * @param {string} enterprise
  * @param {string} owner
  * @param {string[]} repositories
@@ -17,6 +18,7 @@ import isNetworkError from "is-network-error";
 export async function main(
   clientId,
   privateKey,
+  jwt,
   enterprise,
   owner,
   repositories,
@@ -35,7 +37,7 @@ export async function main(
 
   const auth = createAppAuth({
     appId: clientId,
-    privateKey,
+    ...resolveAppAuthStrategyOptions(privateKey, jwt),
     request,
   });
 
@@ -56,6 +58,33 @@ export async function main(
     core.saveState("token", authentication.token);
     core.saveState("expiresAt", authentication.expiresAt);
   }
+}
+
+function resolveAppAuthStrategyOptions(privateKey, jwt) {
+  if (!jwt) return { privateKey };
+
+  // The caller signed the JWT themselves, so pass it on instead of signing one
+  const expiresAt = decodeJwtExpiration(jwt);
+
+  return { createJwt: async () => ({ jwt, expiresAt }) };
+}
+
+function decodeJwtExpiration(jwt) {
+  let exp;
+
+  // The signature is not checked here, GitHub verifies the token
+  try {
+    const [, payload] = jwt.split(".");
+    ({ exp } = JSON.parse(Buffer.from(payload, "base64url").toString()));
+  } catch {
+    throw new Error("The 'jwt' input could not be decoded as a JSON Web Token.");
+  }
+
+  if (typeof exp !== "number") {
+    throw new Error("The 'jwt' input has no numeric 'exp' claim.");
+  }
+
+  return new Date(exp * 1000).toISOString();
 }
 
 function resolveInstallationTarget(enterprise, owner, repositories, core) {

--- a/main.js
+++ b/main.js
@@ -23,8 +23,12 @@ async function run() {
     throw new Error("The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.");
   }
   const privateKey = core.getInput("private-key");
-  if (!privateKey) {
-    throw new Error("The 'private-key' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.");
+  const jwt = core.getInput("jwt");
+  if (!privateKey && !jwt) {
+    throw new Error("Either the 'private-key' or the 'jwt' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.");
+  }
+  if (privateKey && jwt) {
+    throw new Error("The 'private-key' and 'jwt' inputs are mutually exclusive, set only one of them.");
   }
   const enterprise = core.getInput("enterprise");
   const owner = core.getInput("owner");
@@ -41,6 +45,7 @@ async function run() {
   return main(
     clientId,
     privateKey,
+    jwt,
     enterprise,
     owner,
     repositories,

--- a/tests/index.js.snapshot
+++ b/tests/index.js.snapshot
@@ -153,6 +153,49 @@ POST /app/installations/123456/access_tokens
 {"permissions":{"enterprise_custom_properties_for_organizations":"read"}}
 `;
 
+exports[`main-jwt-and-private-key-set.test.js > stderr 1`] = `
+The 'private-key' and 'jwt' inputs are mutually exclusive, set only one of them.
+`;
+
+exports[`main-jwt-and-private-key-set.test.js > stdout 1`] = `
+::error::The 'private-key' and 'jwt' inputs are mutually exclusive, set only one of them.
+`;
+
+exports[`main-jwt-invalid.test.js > stderr 1`] = `
+The 'jwt' input could not be decoded as a JSON Web Token.
+`;
+
+exports[`main-jwt-invalid.test.js > stdout 1`] = `
+Inputs 'owner' and 'repositories' are not set. Creating token for this repository (actions/create-github-app-token).
+::error::The 'jwt' input could not be decoded as a JSON Web Token.
+`;
+
+exports[`main-jwt-missing-expiration.test.js > stderr 1`] = `
+The 'jwt' input has no numeric 'exp' claim.
+`;
+
+exports[`main-jwt-missing-expiration.test.js > stdout 1`] = `
+Inputs 'owner' and 'repositories' are not set. Creating token for this repository (actions/create-github-app-token).
+::error::The 'jwt' input has no numeric 'exp' claim.
+`;
+
+exports[`main-jwt.test.js > stdout 1`] = `
+Inputs 'owner' and 'repositories' are not set. Creating token for this repository (actions/create-github-app-token).
+::add-mask::ghs_16C7e42F292c6912E7710c838347Ae178B4a
+
+::set-output name=token::ghs_16C7e42F292c6912E7710c838347Ae178B4a
+
+::set-output name=installation-id::123456
+
+::set-output name=app-slug::github-actions
+::save-state name=token::ghs_16C7e42F292c6912E7710c838347Ae178B4a
+::save-state name=expiresAt::2016-07-11T22:14:10Z
+--- REQUESTS ---
+GET /repos/actions/create-github-app-token/installation
+POST /app/installations/123456/access_tokens
+{"repositories":["create-github-app-token"]}
+`;
+
 exports[`main-missing-client-and-app-id.test.js > stderr 1`] = `
 The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.
 `;
@@ -166,11 +209,11 @@ GITHUB_REPOSITORY_OWNER missing, must be set to '<owner>'
 `;
 
 exports[`main-missing-private-key.test.js > stderr 1`] = `
-The 'private-key' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.
+Either the 'private-key' or the 'jwt' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.
 `;
 
 exports[`main-missing-private-key.test.js > stdout 1`] = `
-::error::The 'private-key' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.
+::error::Either the 'private-key' or the 'jwt' input must be set to a non-empty string. If using a secret or variable, ensure it is available in this workflow context.
 `;
 
 exports[`main-missing-repository.test.js > stderr 1`] = `

--- a/tests/main-jwt-and-private-key-set.test.js
+++ b/tests/main-jwt-and-private-key-set.test.js
@@ -1,0 +1,20 @@
+import { DEFAULT_ENV } from "./main.js";
+
+for (const [key, value] of Object.entries({
+  ...DEFAULT_ENV,
+  INPUT_JWT:
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MDAwMDAwMDAsImV4cCI6MTcwMDAwMDYwMCwiaXNzIjoiSXYxLjAxMjM0NTY3ODlhYmNkZWYifQ.signature",
+})) {
+  process.env[key] = value;
+}
+
+// Log only the error message, not the full stack trace, because the stack
+// trace contains environment-specific paths and ANSI codes that differ
+// between local and CI environments.
+const _error = console.error;
+console.error = (err) => _error(err?.message ?? err);
+
+// Verify `main` exits with an error when both `private-key` and `jwt` are set.
+const { default: promise } = await import("../main.js");
+await promise;
+process.exitCode = 0;

--- a/tests/main-jwt-invalid.test.js
+++ b/tests/main-jwt-invalid.test.js
@@ -1,0 +1,20 @@
+import { DEFAULT_ENV } from "./main.js";
+
+for (const [key, value] of Object.entries({
+  ...DEFAULT_ENV,
+  "INPUT_PRIVATE-KEY": "",
+  INPUT_JWT: "not-a-json-web-token",
+})) {
+  process.env[key] = value;
+}
+
+// Log only the error message, not the full stack trace, because the stack
+// trace contains environment-specific paths and ANSI codes that differ
+// between local and CI environments.
+const _error = console.error;
+console.error = (err) => _error(err?.message ?? err);
+
+// Verify `main` exits with an error when `jwt` cannot be decoded.
+const { default: promise } = await import("../main.js");
+await promise;
+process.exitCode = 0;

--- a/tests/main-jwt-missing-expiration.test.js
+++ b/tests/main-jwt-missing-expiration.test.js
@@ -1,0 +1,22 @@
+import { DEFAULT_ENV } from "./main.js";
+
+for (const [key, value] of Object.entries({
+  ...DEFAULT_ENV,
+  "INPUT_PRIVATE-KEY": "",
+  // Decodes to `{"iat":1700000000,"iss":"Iv1.0123456789abcdef"}`, without an `exp` claim.
+  INPUT_JWT:
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MDAwMDAwMDAsImlzcyI6Ikl2MS4wMTIzNDU2Nzg5YWJjZGVmIn0.signature",
+})) {
+  process.env[key] = value;
+}
+
+// Log only the error message, not the full stack trace, because the stack
+// trace contains environment-specific paths and ANSI codes that differ
+// between local and CI environments.
+const _error = console.error;
+console.error = (err) => _error(err?.message ?? err);
+
+// Verify `main` exits with an error when `jwt` has no `exp` claim.
+const { default: promise } = await import("../main.js");
+await promise;
+process.exitCode = 0;

--- a/tests/main-jwt.test.js
+++ b/tests/main-jwt.test.js
@@ -1,0 +1,9 @@
+import { DEFAULT_ENV, test } from "./main.js";
+
+// Verify `main` creates a token from a caller-supplied JWT
+await test(() => {}, {
+  ...DEFAULT_ENV,
+  "INPUT_PRIVATE-KEY": "",
+  INPUT_JWT:
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MDAwMDAwMDAsImV4cCI6MTcwMDAwMDYwMCwiaXNzIjoiSXYxLjAxMjM0NTY3ODlhYmNkZWYifQ.signature",
+});

--- a/tests/main.js
+++ b/tests/main.js
@@ -55,6 +55,12 @@ export async function test(cb = (_mockPool) => {}, env = DEFAULT_ENV) {
 
   // Calling `auth({ type: "app" })` to obtain a JWT doesn’t make network requests, so no need to intercept.
 
+  // Unlike a JWT signed from `private-key`, one passed in through the `jwt` input
+  // is idempotent, so assert that it is sent as-is.
+  const appAuthorization = env.INPUT_JWT
+    ? { authorization: `bearer ${env.INPUT_JWT}` }
+    : {};
+
   // Mock installation ID and app slug request
   const mockInstallationId = "123456";
   const mockAppSlug = "github-actions";
@@ -76,7 +82,7 @@ export async function test(cb = (_mockPool) => {}, env = DEFAULT_ENV) {
       headers: {
         accept: "application/vnd.github.v3+json",
         "user-agent": "actions/create-github-app-token",
-        // Intentionally omitting the `authorization` header, since JWT creation is not idempotent.
+        ...appAuthorization,
       },
     })
     .reply(
@@ -97,7 +103,7 @@ export async function test(cb = (_mockPool) => {}, env = DEFAULT_ENV) {
       headers: {
         accept: "application/vnd.github.v3+json",
         "user-agent": "actions/create-github-app-token",
-        // Note: Intentionally omitting the `authorization` header, since JWT creation is not idempotent.
+        ...appAuthorization,
       },
     })
     .reply(


### PR DESCRIPTION
Refs #219.

## Summary

`private-key` requires the app's private key to be present in the workflow. Some setups keep the key in an HSM or a secret store that exposes only a signing endpoint, so the workflow can produce a JWT but never the key. This adds a `jwt` input that accepts such a token.

The wiring is small because `@octokit/auth-app` already supports it: `createJwt` landed in v8.1.0 via octokit/auth-app.js#712, the PR @gr2m linked in #219, and this action already depends on `^8.2.0`, so there is no dependency bump. When `jwt` is set, the action passes `createJwt` instead of `privateKey` and hands the token over unchanged.

## Decisions worth reviewing

**A separate input rather than reusing `private-key`.** #219 raised reusing `private-key` to avoid making it optional. I went with a separate input because sniffing PEM-vs-JWT is guessy and makes the error messages worse. On the DX concern: `required: true` on an action input is not enforced by the runner (actions/runner#1070), so the guard that actually fires is this action's own validation, which now names both inputs, and setting both is a hard error.

**The expiration is read from the token, not taken as a second input.** The caller supplies a finished JWT, so `exp` is already in it. `decodeJwtExpiration` base64url-decodes the payload without verifying the signature; GitHub is what verifies the token. A separate input could only duplicate that value and disagree with it.

**Known limitation.** When GitHub reports clock skew, `@octokit/auth-app` retries by re-signing with a time offset. A caller-supplied JWT cannot be re-signed, so the retry sends the same token. The 10-minute lifetime cannot be renewed either. The README says to sign the token in the step immediately before this one.

## Tests

Four new cases: the happy path, both inputs set, an undecodable token, and a token without a numeric `exp`. Coverage stays at 100%.

The shared `tests/main.js` helper now matches the `authorization` header when `INPUT_JWT` is set. It deliberately did not match it before, because a JWT signed from `private-key` is not idempotent. A supplied one is, so this asserts the token reaches GitHub unchanged.

## Not included

`dist/` is not rebuilt here, since the release workflow commits it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
